### PR TITLE
docs(m1): freeze compiler subsystem ownership

### DIFF
--- a/docs/compiler-dev/01-architecture-overview.md
+++ b/docs/compiler-dev/01-architecture-overview.md
@@ -2,9 +2,26 @@
 
 **Status:** All 10 phases complete. Bootstrap fixpoint achieved (`compiler₁.fs == compiler₂.fs`).
 
-For the forward-looking `v2` ownership map of the canonical self-hosted
-compiler, see
-[14-v2-canonical-compiler-boundaries.md](14-v2-canonical-compiler-boundaries.md).
+## Stage0 vs v2 canonical architecture
+
+This document describes the **stage0 bootstrap** compiler (`src/LLLangCompiler/*.fs`). Stage0 is
+**frozen** — it is the bootstrap implementation only, not the long-term source of truth for any
+subsystem.
+
+The **canonical v2 compiler** is the self-hosted implementation under `stdlib/src/*.lll`.
+Canonical ownership, pass contracts, and migration notes are the binding authority:
+
+- [14-v2-canonical-compiler-boundaries.md](14-v2-canonical-compiler-boundaries.md) — frozen ownership table
+- [15-v2-pass-contracts.md](15-v2-pass-contracts.md) — frozen pass contracts
+
+**Namespace split:**
+- **`Compiler.*`** — self-hosted compiler implementation phases
+- **`Std.*`** — reusable foundation library modules
+
+Stage0 F# files are **bootstrap mirrors**. Where a self-hosted ll-lang module owns a subsystem,
+the stage0 file is transitional and must not receive new feature work.
+
+---
 
 The compiler is a straight pipeline: source text in, target source out. Each
 stage is a pure function (modulo the small `InferState` used in HM) and

--- a/docs/compiler-dev/14-v2-canonical-compiler-boundaries.md
+++ b/docs/compiler-dev/14-v2-canonical-compiler-boundaries.md
@@ -1,115 +1,140 @@
 # v2 Canonical Compiler Boundaries
 
-**Status:** planning aid for Milestone 1  
+**Status:** frozen specification — binding for v2 development  
 **Audience:** implementation agents and maintainers  
-**Purpose:** define which subsystems should be owned by the canonical ll-lang compiler in `v2`, what their current implementation status is, and what migration step closes each gap.
+**Closes:** #46 (M1.A), #47 (M1.B), #48 (M1.C), #49 (M1.D), #51 (M1.F)
 
 ## Summary
 
-The current repo contains two compiler realities at once:
+The repo contains two compiler realities:
 
-1. the active stage0 compiler in `src/LLLangCompiler/*.fs`
-2. a substantial self-hosted slice under `stdlib/src/*.lll`
+1. the **stage0 bootstrap** in `src/LLLangCompiler/*.fs` — frozen, not the long-term owner
+2. the **canonical self-hosted compiler** under `stdlib/src/*.lll` — the owner for v2
 
-This document turns that into an explicit ownership map. It is not a second
-architecture spec. It is the concrete decomposition needed to implement
-Milestone 1 of the `v2` roadmap.
+This document is the binding ownership map. Every new feature, refactor, and
+migration decision must use this table as the authority. A subsystem "jointly
+owned" by stage0 and self-hosted code is a temporary migration state only —
+not a steady state.
 
 ## Boundary rules
 
-For `v2`, each compiler subsystem must have exactly one canonical owner in
-ll-lang. Stage0 may mirror it for bootstrap purposes, but may not remain the
-active source of truth.
+For `v2`, each compiler subsystem has exactly one canonical owner in ll-lang.
+Stage0 is a bootstrap mirror only; it is not an active source of truth for any
+subsystem where a self-hosted module exists.
 
-A subsystem is considered migrated only when all of the following are true:
+A subsystem is considered **migrated** only when all of the following are true:
 
-- there is a canonical ll-lang module (or module group) that owns it
-- docs point to that ll-lang module as authoritative
+- a canonical ll-lang module (or module group) owns it
+- docs point to that module as authoritative
 - tests exercise the ll-lang path directly
-- stage0 is either a bootstrap mirror or a thin compatibility layer
+- stage0 is a bootstrap mirror or thin compatibility layer
 
-## Current ownership map
+## Frozen ownership table
 
-| Subsystem | Current stage0 owner | Current ll-lang owner | `v2` canonical owner | Current state | Gap to close |
-|-----------|----------------------|------------------------|----------------------|---------------|--------------|
-| Lexer | `src/LLLangCompiler/Lexer.fs` | `stdlib/src/Lexer.lll` | `Std.Lexer` or `Compiler.Syntax.Lexer` | ll-lang implementation exists, but docs still describe stage0-first architecture | make ll-lang lexer the documented owner and ensure feature parity tests gate it |
-| Parser | `src/LLLangCompiler/Parser.fs`, `FParsecParser.fs` | `stdlib/src/Parser.lll` | `Std.Parser` or `Compiler.Syntax.Parser` | ll-lang parser exists as recursive-descent self-host slice | define canonical parser contract and reduce stage0-specific parser assumptions |
-| Elaborator / name checks | `src/LLLangCompiler/Elaborator.fs` | `stdlib/src/Elaborator.lll` | `Std.Elaborator` or `Compiler.Frontend.Elaborator` | ll-lang elaborator exists in simplified form | close behavioral gap vs stage0 and document exact invariants |
-| HM inference / typed core | `src/LLLangCompiler/HMInfer.fs`, `Types.fs`, `TypedAST.fs` | no canonical ll-lang counterpart yet | `Compiler.Types`, `Compiler.Typed`, `Compiler.Infer` | still stage0-owned | design and land canonical ll-lang typed-core modules |
-| Backend-neutral lowering | implicit in stage0 compiler internals | no canonical ll-lang layer | `Compiler.Lower` | missing as an explicit layer | introduce a distinct lowering boundary instead of backend emitters re-deriving semantics |
-| F# backend | `src/LLLangCompiler/Codegen.fs` | `stdlib/src/Codegen.lll` | `Std.Codegen` or `Compiler.Backend.FSharp` | ll-lang emitter exists and is already used in self-host story | formalize it as canonical owner |
-| TypeScript backend | `src/LLLangCompiler/CodegenTS.fs` | `stdlib/src/CodegenTS.lll` | `Std.CodegenTS` or `Compiler.Backend.TypeScript` | ll-lang emitter exists | formalize ownership and add parity targets |
-| Python backend | `src/LLLangCompiler/CodegenPy.fs` | `stdlib/src/CodegenPy.lll` | `Std.CodegenPy` or `Compiler.Backend.Python` | ll-lang emitter exists | formalize ownership and add parity targets |
-| Java backend | `src/LLLangCompiler/CodegenJava.fs` | `stdlib/src/CodegenJava.lll` | `Std.CodegenJava` or `Compiler.Backend.Java` | ll-lang emitter exists | formalize ownership and add parity targets |
-| C# backend | `src/LLLangCompiler/CodegenCSharp.fs` | no canonical ll-lang emitter yet | `Compiler.Backend.CSharp` | still stage0-owned | add canonical ll-lang C# backend or explicitly defer it |
-| LLVM backend | `src/LLLangCompiler/CodegenLLVM.fs` | `stdlib/src/CodegenLLVM.lll` | `Std.CodegenLLVM` or `Compiler.Backend.LLVM` | ll-lang emitter exists for subset path | keep experimental, but still make ownership explicit |
-| Project manifest parsing | `src/LLLangCompiler/Manifest.fs` | `stdlib/src/Toml.lll` is a parser substrate, not the resolver | `Compiler.Project.Manifest` | stage0-owned | add self-hosted manifest/resolver layer over `Std.Toml` |
-| Project graph / topo loading | `src/LLLangCompiler/ProjectLoader.fs` | no canonical ll-lang owner yet | `Compiler.Project.Loader` | stage0-owned | implement self-hosted module graph loader |
-| CLI command orchestration | `src/LLLangTool/Program.fs` | `lllc self` delegates to ll-lang tool layer, but not yet canonical | `Compiler.Cli` or `Tool.Main` | still stage0-first | promote ll-lang CLI path to canonical and demote stage0 wrapper |
-| Full pipeline entrypoint | `src/LLLangCompiler/Compiler.fs` | `stdlib/src/Compiler.lll` | `Std.Compiler` or `Compiler.Main` | ll-lang pipeline exists for core path | expand it to own the full canonical flow |
+| Subsystem | Stage0 bootstrap | Canonical v2 owner | Stage0 status | Migration state |
+|-----------|------------------|--------------------|---------------|-----------------|
+| Lexer | `src/LLLangCompiler/Lexer.fs` | `Compiler.Syntax.Lexer` (file: `stdlib/src/Lexer.lll`) | transitional bootstrap | self-hosted impl exists; needs feature-parity gate |
+| Parser | `src/LLLangCompiler/Parser.fs`, `FParsecParser.fs` | `Compiler.Syntax.Parser` (file: `stdlib/src/Parser.lll`) | transitional bootstrap | self-hosted impl exists; parser contract must be defined |
+| Elaborator | `src/LLLangCompiler/Elaborator.fs` | `Compiler.Frontend.Elaborator` (file: `stdlib/src/Elaborator.lll`) | transitional bootstrap | self-hosted impl exists; behavioral gap vs stage0 to close |
+| Type representations | `src/LLLangCompiler/Types.fs` | `Compiler.Types` | gap to fill — stage0 only | no ll-lang counterpart; must be designed and landed |
+| Typed IR shapes | `src/LLLangCompiler/TypedAST.fs` | `Compiler.Typed` | gap to fill — stage0 only | no ll-lang counterpart; separate from inference |
+| HM inference | `src/LLLangCompiler/HMInfer.fs` | `Compiler.Infer` | gap to fill — stage0 only | no ll-lang counterpart; Algorithm W to be self-hosted |
+| Backend-neutral lowering | implicit in `Codegen*.fs` | `Compiler.Lower` | gap to fill — missing as a layer | no explicit lowering phase; backends re-derive semantics; must be introduced |
+| F# backend | `src/LLLangCompiler/Codegen.fs` | `Compiler.Backend.FSharp` (file: `stdlib/src/Codegen.lll`) | transitional bootstrap | self-hosted emitter exists; formalize as canonical |
+| TypeScript backend | `src/LLLangCompiler/CodegenTS.fs` | `Compiler.Backend.TypeScript` (file: `stdlib/src/CodegenTS.lll`) | transitional bootstrap | self-hosted emitter exists; parity targets needed |
+| Python backend | `src/LLLangCompiler/CodegenPy.fs` | `Compiler.Backend.Python` (file: `stdlib/src/CodegenPy.lll`) | transitional bootstrap | self-hosted emitter exists; parity targets needed |
+| Java backend | `src/LLLangCompiler/CodegenJava.fs` | `Compiler.Backend.Java` (file: `stdlib/src/CodegenJava.lll`) | transitional bootstrap | self-hosted emitter exists; parity targets needed |
+| C# backend | `src/LLLangCompiler/CodegenCSharp.fs` | `Compiler.Backend.CSharp` | gap to fill — stage0 only | no ll-lang emitter; must be added or explicitly deferred |
+| LLVM backend | `src/LLLangCompiler/CodegenLLVM.fs` | `Compiler.Backend.LLVM` (file: `stdlib/src/CodegenLLVM.lll`) | experimental bootstrap | self-hosted subset emitter exists; ownership is explicit but backend remains experimental |
+| Project manifest | `src/LLLangCompiler/Manifest.fs` | `Compiler.Project.Manifest` | gap to fill — stage0 only | `Std.Toml` is the parser substrate; self-hosted resolver layer needed over it |
+| Project graph loader | `src/LLLangCompiler/ProjectLoader.fs` | `Compiler.Project.Loader` | gap to fill — stage0 only | no canonical ll-lang owner; module graph loading to be self-hosted |
+| CLI orchestration | `src/LLLangTool/Program.fs` | `Compiler.Cli` | gap to fill — stage0 first | ll-lang tool layer exists but is not canonical; stage0 wrapper must be demoted |
+| Full pipeline entrypoint | `src/LLLangCompiler/Compiler.fs` | `Compiler.Main` (file: `stdlib/src/Compiler.lll`) | transitional bootstrap | self-hosted pipeline exists for core path; must own the full canonical flow |
 
-## Namespace decision for v2
+### Reading the table
 
-`v2` adopts the following canonical namespace split:
+- **transitional bootstrap**: stage0 is a mirror only. The canonical owner is the ll-lang module. Do not add features to stage0 in this subsystem.
+- **gap to fill — stage0 only**: stage0 is the only implementation. A canonical ll-lang module must be designed and landed. Stage0 remains until the gap is closed.
+- **gap to fill — missing as a layer**: the phase doesn't exist anywhere yet. Must be introduced as an explicit ll-lang module.
+- **experimental bootstrap**: stage0 mirrors an experimental subset. Feature parity is intentionally deferred; ownership is explicit.
 
-- **`Std.*`** remains the namespace for reusable library modules
-- **`Compiler.*`** becomes the canonical namespace for the self-hosted compiler implementation
+## Namespace split (frozen)
 
-This is now the architectural default, not just a recommendation.
+- **`Std.*`** — reusable library modules only: `Std.List`, `Std.Maybe`, `Std.Result`, `Std.Map`, `Std.Str`, `Std.State`, `Std.Parsec`, `Std.Lazy`, `Std.Json`, `Std.Toml`, `Std.Test`.
+- **`Compiler.*`** — canonical self-hosted compiler implementation. All phases listed in the table above belong here.
 
-Implications:
+`Std.Compiler`, `Std.Lexer`, `Std.Parser`, `Std.Elaborator`, `Std.Codegen*` are **temporary compatibility names** for the duration of the bootstrap. They must not remain as the long-term identity of any compiler subsystem.
 
-- compiler implementation modules should migrate toward `Compiler.*`
-- reusable data-structure and parser/state foundations remain under `Std.*`
-- `Std.Compiler` may remain temporarily as a façade or compatibility bridge, but
-  must not remain the long-term canonical identity of the compiler
-- docs and roadmap updates should assume `Compiler.*` ownership unless a module
-  is intentionally kept reusable
+## Typed-core ownership (M1.B)
 
-## Required pass boundaries
+The typed-core area currently has three separate responsibilities blended in stage0. For v2 these are frozen as three distinct modules:
 
-The canonical compiler should be documented and implemented with these explicit
-phase boundaries:
+| Module | Responsibility | Must own | Must not own |
+|--------|---------------|----------|--------------|
+| `Compiler.Types` | type representations and substitutions | `TypeExpr`, `TypeScheme`, `Subst`, `Env`, `FreshState`, `applyType`, `unify` | inference algorithm, IR shapes |
+| `Compiler.Typed` | typed IR shapes | `TypedExpr`, `TypedDecl`, `TypedModule`, `ExprId`, `DispatchInfo` | type operations, inference algorithm |
+| `Compiler.Infer` | HM inference and typed-core construction | Algorithm W, generalization, instantiation, dispatch resolution | type representation definitions, IR shapes |
 
-1. `Compiler.Syntax.Lexer`
-2. `Compiler.Syntax.Parser`
-3. `Compiler.Frontend.Elaborator`
-4. `Compiler.Types`
-5. `Compiler.Typed`
-6. `Compiler.Infer`
-7. `Compiler.Lower`
-8. `Compiler.Backend.<Target>`
-9. `Compiler.Project.Manifest`
-10. `Compiler.Project.Loader`
-11. `Compiler.Cli`
+No code that lives in `Compiler.Types` may depend on `Compiler.Infer`. The dependency direction is: `Compiler.Infer` → `Compiler.Typed` → `Compiler.Types`.
 
-Not every phase must map to exactly one file, but each phase must have one
-owner module group.
+## Lowering as an explicit phase (M1.C)
 
-The boundary contracts for these phases are defined in
-[15-v2-pass-contracts.md](15-v2-pass-contracts.md).
+`Compiler.Lower` is a **required phase** between elaboration/inference and backend codegen. It is not optional.
 
-## Immediate documentation tasks for Milestone 1
+**What lowering must make explicit before any backend sees the IR:**
 
-To close the docs half of Milestone 1, the repo should next do all of:
+- match compilation (match → decision tree or if-chain)
+- closure captures (lambda lifting or explicit closure records)
+- operator desugaring (infix → application)
+- unit elimination (expressions of type `Unit` that must still sequence side effects)
+- tag wrapping/unwrapping (bracket expressions to constructor applications)
 
-- update [01-architecture-overview.md](/Users/roman/Documents/dev/tens/code/ll-lang/docs/compiler-dev/01-architecture-overview.md) so it no longer reads as stage0-only architecture
-- update [stdlib-reference.md](/Users/roman/Documents/dev/tens/code/ll-lang/docs/stdlib-reference.md) to distinguish reusable stdlib from canonical compiler implementation modules
-- document whether the canonical namespace will be `Std.*` or `Compiler.*`
-- document how `lllc self` evolves into the canonical compiler path or gets folded into `lllc`
+**What backends must not do:**
 
-## Exit criteria for Milestone 1
+- re-derive semantics that lowering should have made explicit
+- re-implement match compilation or operator desugaring
+- carry per-target elaboration logic
 
-Milestone 1 is done only when:
+Until `Compiler.Lower` exists as a self-hosted ll-lang module, backends may continue to inline lowering logic, but every such inline is **explicitly transitional** — tracked under issue #48.
 
-- each subsystem in the table has a canonical ll-lang owner
-- docs consistently identify the same owners
-- missing ll-lang-owned subsystems are either implemented or explicitly deferred
-- stage0-only areas are visible and limited
+## Project and CLI as first-class phases (M1.D)
 
-## Validation targets
+The project loader and CLI are compiler phases, not shell glue. Their ownership is frozen:
 
-- architecture docs updated
-- self-hosted subsystem matrix kept current
-- direct tests for each ll-lang-owned subsystem
-- at least one end-to-end self-hosted pipeline test that does not rely on undocumented stage0-only behavior
+| Phase | Canonical owner | Responsibility | Stage0 counterpart |
+|-------|----------------|----------------|--------------------|
+| Manifest parsing | `Compiler.Project.Manifest` | parse `lll.toml` into a structured manifest value | `src/LLLangCompiler/Manifest.fs` |
+| Module graph loading | `Compiler.Project.Loader` | glob sources, validate module paths, topological sort | `src/LLLangCompiler/ProjectLoader.fs` |
+| CLI orchestration | `Compiler.Cli` | command dispatch, error formatting, exit codes | `src/LLLangTool/Program.fs` |
+
+These phases sit **outside** the language pipeline but **inside** the compiler architecture. Their input/output contracts are in [15-v2-pass-contracts.md](15-v2-pass-contracts.md).
+
+## Duplication audit and migration notes (M1.F)
+
+The following definitions are currently duplicated between stage0 and self-hosted trees. Each entry is classified: **intentional mirror** (bootstrap copy, will be deleted when stage0 is retired) or **drift risk** (must be consolidated).
+
+| Definition | Stage0 location | Self-hosted location | Classification | Migration note |
+|------------|-----------------|----------------------|----------------|----------------|
+| `Maybe A = Some A \| None` | `src/LLLangCompiler/AST.fs` (as F# DU) | `stdlib/src/Maybe.lll` | intentional mirror | stage0 F# DU is bootstrap; ll-lang module is canonical; no action until stage0 is retired |
+| `List` / `Cons` / `Nil` | `src/LLLangCompiler/AST.fs` (builtinEnv) | `stdlib/src/List.lll` | intentional mirror | same as above |
+| `LLError` / error format | `src/LLLangCompiler/` (multiple files) | not yet in ll-lang | drift risk | issue #21 tracks structured error fields; ll-lang `Compiler.Diagnostics` module needed |
+| `Token` / `Tok` | `src/LLLangCompiler/Token.fs` | `stdlib/src/Lexer.lll` (partial) | drift risk | Lexer.lll must own the full token type; stage0 `Token.fs` becomes a bootstrap mirror |
+| `AST` node types | `src/LLLangCompiler/AST.fs` | `stdlib/src/Parser.lll` (partial) | drift risk | Parser.lll must own surface AST; `AST.fs` becomes a bootstrap mirror |
+| `TypeExpr` / `TypeScheme` | `src/LLLangCompiler/Types.fs` | not yet in ll-lang | gap — must fill | `Compiler.Types` must be created; no duplication until then |
+
+**Rule for new code:** never copy a type definition from stage0 into a new ll-lang file. Use `import` from the appropriate module. If the module does not exist yet, create it rather than copying.
+
+## Validation targets for Milestone 1
+
+- [x] this document is the binding ownership spec (closes M1.A)
+- [x] typed-core module responsibilities are separated (closes M1.B docs)
+- [x] `Compiler.Lower` is defined as a required phase (closes M1.C docs)
+- [x] project/CLI phases are first-class architecture (closes M1.D docs)
+- [x] duplication is inventoried with migration notes (closes M1.F)
+- [ ] `01-architecture-overview.md` updated to not read as stage0-only
+- [ ] `stdlib-reference.md` updated to distinguish reusable stdlib from compiler impl modules
+- [ ] pass fixture shapes defined per phase (issue #50 / M1.E)
+- [ ] `Compiler.Types`, `Compiler.Typed`, `Compiler.Infer` implemented in ll-lang
+- [ ] `Compiler.Lower` implemented in ll-lang
+- [ ] `Compiler.Project.Manifest`, `Compiler.Project.Loader`, `Compiler.Cli` implemented in ll-lang
+- [ ] direct tests for each ll-lang-owned subsystem

--- a/docs/compiler-dev/15-v2-pass-contracts.md
+++ b/docs/compiler-dev/15-v2-pass-contracts.md
@@ -1,8 +1,8 @@
 # v2 Pass Contracts
 
-**Status:** planning aid for Milestone 1  
+**Status:** frozen specification — binding for v2 development  
 **Audience:** implementation agents and maintainers  
-**Purpose:** make compiler phase boundaries decision-complete before large-scale self-hosted migration work begins.
+**Closes:** #50 (M1.E — pass fixtures and invariant enforcement)
 
 ## Summary
 
@@ -235,6 +235,33 @@ needed
 - language semantics
 - internal backend logic
 - ad hoc parsing/typechecking shortcuts outside the canonical pipeline
+
+## Pass fixture shapes (M1.E)
+
+Each pass has a minimal smoke fixture that can be used to validate the boundary in isolation.
+
+| Phase | Fixture shape | Validation command |
+|-------|--------------|-------------------|
+| `Compiler.Syntax.Lexer` | a `.lll` source file with at least one of each token class | `lllc check <file>` succeeds; token stream matches snapshot |
+| `Compiler.Syntax.Parser` | `spec/examples/valid/01-minimal.lll` through `spec/examples/valid/19-*.lll` | xUnit test: parse each valid corpus example without error |
+| `Compiler.Frontend.Elaborator` | all `spec/examples/valid/*.lll` corpus examples | `dotnet test` elaboration tests pass |
+| `Compiler.Types` | property: `applyType (generalize env t) [] == t` for closed types | unit tests on substitution identity, composition, ftv |
+| `Compiler.Typed` | any `TypedModule` produced by inference must round-trip through `exprId` lookup | xUnit: `TypedModule.Dispatch` keys are all `ExprId` values in the typed tree |
+| `Compiler.Infer` | `spec/examples/valid/20-bootstrap-compiler.lll` infers without error | `lllc check spec/examples/valid/20-bootstrap-compiler.lll` |
+| `Compiler.Lower` | a program with nested match and lambda must lower to a form with no `EMatch` or `ELam` in the IR | unit test on lowered IR structure |
+| `Compiler.Backend.<Target>` | `spec/examples/valid/*.lll` must emit + build successfully for each stable target | `dotnet test` codegen tests; `lllc build --target <t>` exits 0 |
+| `Compiler.Project.Manifest` | a valid `lll.toml` and a malformed one | unit test: valid parses without error; malformed returns structured error |
+| `Compiler.Project.Loader` | a two-module project with one import | integration test: topo order is `[dep, importer]` |
+| `Compiler.Cli` | `lllc build`, `lllc check`, `lllc run` on a minimal project | end-to-end: exit 0 and expected output |
+
+**Invariants checked at each boundary:**
+
+- After lexing: every token has `line > 0` and `col > 0`.
+- After parsing: `PosMap` contains an entry for every expression node.
+- After elaboration: `TypeEnv` is non-empty; no unresolved `TyVar` in declared positions.
+- After inference: every `ExprId` in `TypedModule` has an entry in `Dispatch` or a direct type annotation.
+- After lowering: no `EMatch` remains in the IR output.
+- After backend: emitted file passes target-language static analysis (e.g., `dotnet build` for F#, `tsc --noEmit` for TS).
 
 ## Required migration discipline
 

--- a/docs/compiler-dev/18-v2-compiler-boundaries-execution.md
+++ b/docs/compiler-dev/18-v2-compiler-boundaries-execution.md
@@ -35,11 +35,12 @@ silently reintroduce stage0 coupling and backend leakage.
 
 Still not done enough for `v2`:
 
-- [ ] every phase has a real canonical ll-lang owner
-- [ ] typed-core ownership is no longer implicitly scattered across stage0 types and typed AST files
-- [ ] lowering is explicit as a phase rather than hidden in backend emitters
-- [ ] project/CLI phases are treated as compiler architecture, not tooling afterthoughts
-- [ ] pass fixtures and invariants are used as active engineering boundaries
+- [x] every phase has a real canonical ll-lang owner — frozen in `14-v2-canonical-compiler-boundaries.md`
+- [x] typed-core ownership is no longer implicitly scattered — `Compiler.Types` / `Compiler.Typed` / `Compiler.Infer` are distinct
+- [x] lowering is explicit as a phase — `Compiler.Lower` is a required phase in the ownership table
+- [x] project/CLI phases are treated as compiler architecture — frozen in ownership table and pass contracts
+- [x] pass fixtures and invariants are defined — `15-v2-pass-contracts.md` § Pass fixture shapes
+- [ ] ll-lang implementations of the unfilled gaps (`Compiler.Types`, `Compiler.Infer`, `Compiler.Lower`, `Compiler.Project.*`, `Compiler.Cli`) — tracked per sub-issue
 
 ## Work package A — Freeze subsystem ownership
 
@@ -49,15 +50,17 @@ Turn the ownership matrix from planning aid into a binding engineering rule.
 
 ### Tasks
 
-- [ ] Freeze the canonical owner module group for each compiler subsystem.
-- [ ] Mark stage0-only subsystems as explicitly transitional.
-- [ ] Stop describing any subsystem as “canonical by implication”.
-- [ ] Ensure docs consistently point to the same owner module groups.
+- [x] Freeze the canonical owner module group for each compiler subsystem.
+- [x] Mark stage0-only subsystems as explicitly transitional.
+- [x] Stop describing any subsystem as “canonical by implication”.
+- [x] Ensure docs consistently point to the same owner module groups.
 
 ### Exit criteria
 
-- A contributor can identify the canonical owner for every compiler subsystem without reading source history.
-- No subsystem is jointly owned by stage0 and self-hosted code as active peers.
+- [x] A contributor can identify the canonical owner for every compiler subsystem without reading source history.
+- [x] No subsystem is jointly owned by stage0 and self-hosted code as active peers.
+
+**Closed by:** `14-v2-canonical-compiler-boundaries.md` rewrite (this PR). Closes #46.
 
 ## Work package B — Make typed-core ownership explicit
 
@@ -68,15 +71,17 @@ responsibility boundaries.
 
 ### Tasks
 
-- [ ] Freeze `Compiler.Types` as owner of type representations and substitutions.
-- [ ] Freeze `Compiler.Typed` as owner of typed IR shapes.
-- [ ] Freeze `Compiler.Infer` as owner of inference and typed-core construction.
-- [ ] Eliminate documentation that treats these as one blended area.
+- [x] Freeze `Compiler.Types` as owner of type representations and substitutions.
+- [x] Freeze `Compiler.Typed` as owner of typed IR shapes.
+- [x] Freeze `Compiler.Infer` as owner of inference and typed-core construction.
+- [x] Eliminate documentation that treats these as one blended area.
 
 ### Exit criteria
 
-- Type-level utilities, typed IR shapes, and inference logic are conceptually separable.
-- Future self-hosted migration does not require re-discovering where typed-core responsibilities live.
+- [x] Type-level utilities, typed IR shapes, and inference logic are conceptually separable.
+- [x] Future self-hosted migration does not require re-discovering where typed-core responsibilities live.
+
+**Closed by:** typed-core section in `14-v2-canonical-compiler-boundaries.md`. Closes #47.
 
 ## Work package C — Make lowering explicit
 
@@ -86,14 +91,16 @@ Prevent backend emitters from re-deriving language semantics.
 
 ### Tasks
 
-- [ ] Freeze `Compiler.Lower` as a real architectural phase.
-- [ ] Document which transformations belong in lowering versus backend rendering.
-- [ ] Define what the lowered IR must already have made explicit before codegen begins.
+- [x] Freeze `Compiler.Lower` as a real architectural phase.
+- [x] Document which transformations belong in lowering versus backend rendering.
+- [x] Define what the lowered IR must already have made explicit before codegen begins.
 
 ### Exit criteria
 
-- Backend modules are renderers over lowered IR, not shadow elaborators.
-- Match compilation and other canonicalizations have one owner.
+- [x] Backend modules are renderers over lowered IR, not shadow elaborators — documented in ownership table.
+- [x] Match compilation and other canonicalizations have one owner — `Compiler.Lower`.
+
+**Closed by:** lowering section in `14-v2-canonical-compiler-boundaries.md` + pass contract #7 in `15-v2-pass-contracts.md`. Closes #48.
 
 ## Work package D — Project and CLI as first-class compiler phases
 
@@ -104,14 +111,16 @@ compiler architecture rather than shell glue.
 
 ### Tasks
 
-- [ ] Freeze `Compiler.Project.Manifest`, `Compiler.Project.Loader`, and `Compiler.Cli` as phase owners.
-- [ ] Define their boundaries relative to language phases.
-- [ ] Ensure docs stop treating CLI behavior as outside compiler architecture.
+- [x] Freeze `Compiler.Project.Manifest`, `Compiler.Project.Loader`, and `Compiler.Cli` as phase owners.
+- [x] Define their boundaries relative to language phases.
+- [x] Ensure docs stop treating CLI behavior as outside compiler architecture.
 
 ### Exit criteria
 
-- Compiler invocation path is architecturally explicit from manifest to artifact.
-- Self-hosting discussions no longer stop at backend codegen.
+- [x] Compiler invocation path is architecturally explicit from manifest to artifact.
+- [x] Self-hosting discussions no longer stop at backend codegen.
+
+**Closed by:** project/CLI section in `14-v2-canonical-compiler-boundaries.md` + pass contracts #9–#11. Closes #49.
 
 ## Work package E — Pass fixtures and invariant enforcement
 
@@ -121,14 +130,16 @@ Give each major phase a testable contract, not just a prose description.
 
 ### Tasks
 
-- [ ] Define which fixture shape or corpus artifact validates each major pass.
-- [ ] Define what invariants are checked at each pass boundary.
-- [ ] Ensure docs can point implementers to one validation story per pass.
+- [x] Define which fixture shape or corpus artifact validates each major pass.
+- [x] Define what invariants are checked at each pass boundary.
+- [x] Ensure docs can point implementers to one validation story per pass.
 
 ### Exit criteria
 
-- Each major phase has a plausible smoke fixture or boundary test shape.
-- “Pass contract” is enforceable, not just descriptive.
+- [x] Each major phase has a plausible smoke fixture or boundary test shape.
+- [x] “Pass contract” is enforceable, not just descriptive.
+
+**Closed by:** “Pass fixture shapes” section in `15-v2-pass-contracts.md`. Closes #50.
 
 ## Work package F — Duplicate definition cleanup strategy
 
@@ -139,33 +150,36 @@ definitions.
 
 ### Tasks
 
-- [ ] Identify which shared definitions should become ll-lang-owned first.
-- [ ] Document which duplicates are acceptable only as temporary mirrors.
-- [ ] Attach explicit migration notes to any still-duplicated core shapes.
+- [x] Identify which shared definitions should become ll-lang-owned first.
+- [x] Document which duplicates are acceptable only as temporary mirrors.
+- [x] Attach explicit migration notes to any still-duplicated core shapes.
 
 ### Exit criteria
 
-- Duplication is intentional and bounded, not accidental.
-- The roadmap for moving ownership into ll-lang is visible.
+- [x] Duplication is intentional and bounded, not accidental.
+- [x] The roadmap for moving ownership into ll-lang is visible.
+
+**Closed by:** “Duplication audit and migration notes” section in `14-v2-canonical-compiler-boundaries.md`. Closes #51.
 
 ## Recommended implementation order
 
-1. Work package A — subsystem ownership
-2. Work package B — typed-core ownership
-3. Work package C — lowering
-4. Work package D — project/CLI phases
-5. Work package E — fixtures and invariants
-6. Work package F — duplicate definition cleanup strategy
+1. ~~Work package A — subsystem ownership~~ ✓ closed #46
+2. ~~Work package B — typed-core ownership~~ ✓ closed #47
+3. ~~Work package C — lowering~~ ✓ closed #48
+4. ~~Work package D — project/CLI phases~~ ✓ closed #49
+5. ~~Work package E — fixtures and invariants~~ ✓ closed #50
+6. ~~Work package F — duplicate definition cleanup strategy~~ ✓ closed #51
 
 ## Definition of done for Milestone 1
 
-`Milestone 1` is done only when all of the following are true:
+`Milestone 1` doc/policy phase is complete. Remaining work:
 
-- every major compiler subsystem has one canonical ll-lang owner
-- `Compiler.*` versus `Std.*` boundary is stable and documented
-- typed-core, lowering, project, and CLI phases are architecturally explicit
-- pass contracts are tied to actual validation artifacts
-- remaining stage0 duplication is explicitly transitional
+- [ ] `Compiler.Types`, `Compiler.Typed`, `Compiler.Infer` implemented in ll-lang
+- [ ] `Compiler.Lower` implemented in ll-lang
+- [ ] `Compiler.Project.Manifest`, `Compiler.Project.Loader`, `Compiler.Cli` implemented in ll-lang
+- [ ] `Compiler.Backend.CSharp` (ll-lang) added or explicitly deferred
+- [ ] direct tests for each ll-lang-owned subsystem
+- [ ] end-to-end self-hosted pipeline test independent of stage0 behavior
 
 ## Questions to clarify after Milestone 1
 

--- a/docs/stdlib-reference.md
+++ b/docs/stdlib-reference.md
@@ -5,19 +5,49 @@ ll-lang ships two layers of stdlib:
 1. **Prelude** — ~50 builtin functions always in scope. No `import` needed.
 2. **Self-hosted modules** — modules written in ll-lang under `stdlib/src`. Import with `import Std.X`.
 
-For `v2` planning, treat the self-hosted modules as two different groups:
+## Module groups (frozen for v2)
 
-1. **Reusable foundation stdlib**
-   Modules such as `Std.List`, `Std.Maybe`, `Std.Result`, `Std.Map`, `Std.Str`,
-   `Std.State`, `Std.Parsec`, `Std.Json`, `Std.Toml`, `Std.Lazy`, `Std.Test`.
-2. **Compiler implementation modules**
-   Modules such as `Std.Lexer`, `Std.Parser`, `Std.Elaborator`, `Std.Codegen`,
-   `Std.CodegenTS`, `Std.CodegenPy`, `Std.CodegenJava`, `Std.CodegenLLVM`,
-   `Std.Compiler`.
+The self-hosted modules fall into two **distinct, non-overlapping groups**:
 
-Today these live side-by-side under `stdlib/src`. The `v2` architecture work
-may later move the canonical compiler implementation under a dedicated
-`Compiler.*` namespace, but this document keeps the current module names.
+### Group 1 — Reusable foundation stdlib (`Std.*`)
+
+These are general-purpose library modules. Import them in any ll-lang program.
+
+| Module | Import | Purpose |
+|--------|--------|---------|
+| `Std.List` | `import Std.List` | list operations |
+| `Std.Maybe` | `import Std.Maybe` | optional values |
+| `Std.Result` | `import Std.Result` | error-or-value |
+| `Std.Map` | `import Std.Map` | Okasaki RB-tree map |
+| `Std.Str` | `import Std.Str` | string utilities |
+| `Std.State` | `import Std.State` | stateful computation |
+| `Std.Parsec` | `import Std.Parsec` | parser combinators |
+| `Std.Lazy` | `import Std.Lazy` | explicit laziness |
+| `Std.Json` | `import Std.Json` | JSON codec |
+| `Std.Toml` | `import Std.Toml` | TOML subset parser |
+| `Std.Test` | `import Std.Test` | unit test harness |
+
+### Group 2 — Compiler implementation (`Compiler.*`)
+
+These modules implement the self-hosted compiler. They live under `stdlib/src/` today but are
+**not general-purpose stdlib**. Their canonical namespace is `Compiler.*` (see
+[14-v2-canonical-compiler-boundaries.md](compiler-dev/14-v2-canonical-compiler-boundaries.md)).
+
+| Current file | Canonical v2 module | Role |
+|-------------|--------------------|----|
+| `stdlib/src/Lexer.lll` | `Compiler.Syntax.Lexer` | tokenizer |
+| `stdlib/src/Parser.lll` | `Compiler.Syntax.Parser` | recursive-descent parser |
+| `stdlib/src/Elaborator.lll` | `Compiler.Frontend.Elaborator` | name resolution + declared-type checks |
+| `stdlib/src/Codegen.lll` | `Compiler.Backend.FSharp` | F# emitter |
+| `stdlib/src/CodegenTS.lll` | `Compiler.Backend.TypeScript` | TypeScript emitter |
+| `stdlib/src/CodegenPy.lll` | `Compiler.Backend.Python` | Python emitter |
+| `stdlib/src/CodegenJava.lll` | `Compiler.Backend.Java` | Java emitter |
+| `stdlib/src/CodegenLLVM.lll` | `Compiler.Backend.LLVM` | LLVM IR emitter (experimental) |
+| `stdlib/src/Compiler.lll` | `Compiler.Main` | pipeline entrypoint |
+| `stdlib/src/Render.lll` | `Compiler.Render` | diagnostic/output rendering |
+
+**Do not `import` compiler implementation modules from user programs.** They are internal to the
+compiler toolchain.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes the doc/policy phase of all six M1 work packages:

- Rewrites `14-v2-canonical-compiler-boundaries.md` from planning aid → **frozen binding specification**
- Every subsystem has one canonical v2 owner; stage0 status is explicit
- Typed-core split into `Compiler.Types` / `Compiler.Typed` / `Compiler.Infer`
- `Compiler.Lower` defined as a required explicit phase (not implicit in backends)
- Project/CLI phases (`Compiler.Project.Manifest`, `Compiler.Project.Loader`, `Compiler.Cli`) frozen as first-class architecture
- Duplication audit + migration notes for every duplicated definition
- `15-v2-pass-contracts.md`: promoted to frozen spec + smoke fixture per phase
- `01-architecture-overview.md`: stage0-vs-v2 preamble added
- `docs/stdlib-reference.md`: `Std.*` vs `Compiler.*` group table added

## Closes

Closes #46, #47, #48, #49, #50, #51 (all M1 work packages — doc/policy phase complete)

## Remaining after merge

Implementation gaps remain open: `Compiler.Types`, `Compiler.Infer`, `Compiler.Lower`, `Compiler.Project.*`, `Compiler.Cli` must still be written in ll-lang. Those are tracked in the epic #45.