### PR TITLE
refactor(#21): add Body field to LLError, eliminate string-parsing in repos

### DIFF
--- a/src/LLLangCompiler/Compiler.fs
+++ b/src/LLLangCompiler/Compiler.fs
@@ -20,7 +20,7 @@ let CSharp = Target.CSharp
 let LLVM = Target.LLVM
 
 let private wrapErr (msg: string) : LLError list =
-    [{ Code = E001; Line = 0; Col = 0; Message = msg }]
+    [mkLLError E001 0 0 msg]
 
 let private parseModuleWithPosFromSrc (src: string) : Result<LLModule * PosMap, LLError list> =
     match tokenize src with
@@ -66,18 +66,8 @@ let private importedSchemesToElaboratorEnv (importedEnv: Env) : Elaborator.TypeE
 
 let private externalMappingError (target: Target) (pm: PosMap) (sigRecord: FnSig) : LLError =
     let pos = PosMap.tryFind pm (box sigRecord)
-    {
-        Code = E026
-        Line = pos.Line
-        Col = pos.Col
-        Message =
-            sprintf
-                "E026 %d:%d UnknownExternalMapping target:%s name:%s"
-                pos.Line
-                pos.Col
-                (targetPlatformName target)
-                sigRecord.Name
-    }
+    mkLLError E026 pos.Line pos.Col
+        (sprintf "UnknownExternalMapping target:%s name:%s" (targetPlatformName target) sigRecord.Name)
 
 let private validateExternalMappingsForTarget (target: Target) (pm: PosMap) (m: LLModule) : LLError list =
     m.Decls

--- a/src/LLLangCompiler/Elaborator.fs
+++ b/src/LLLangCompiler/Elaborator.fs
@@ -12,17 +12,22 @@ type LLError = {
     Code: ErrorCode
     Line: int
     Col: int
-    /// Compact format: "E001 12:5 TypeMismatch Str Str[UserId]"
+    /// Position-free detail: "TypeMismatch Str Str[UserId]" (no code or pos prefix).
+    /// Used to rebuild Message when position is patched in after construction.
+    Body: string
+    /// Full compact format: "E001 12:5 TypeMismatch Str Str[UserId]"
     Message: string
 }
 
-let private e003 line col typeName missing = {
-    Code = E003; Line = line; Col = col
-    Message = sprintf "E003 %d:%d NonExhaustiveMatch %s missing:%s" line col typeName missing }
+let internal mkLLError code line col body = {
+    Code = code; Line = line; Col = col; Body = body
+    Message = sprintf "%s %d:%d %s" (code.ToString()) line col body }
 
-let private e026 line col target name = {
-    Code = E026; Line = line; Col = col
-    Message = sprintf "E026 %d:%d UnknownExternalMapping target:%s name:%s" line col target name }
+let private e003 line col typeName missing =
+    mkLLError E003 line col (sprintf "NonExhaustiveMatch %s missing:%s" typeName missing)
+
+let private e026 line col target name =
+    mkLLError E026 line col (sprintf "UnknownExternalMapping target:%s name:%s" target name)
 
 /// Arithmetic and comparison operators pre-populated as TyVar wildcards.
 /// These are parsed as EApp(EApp(EVar "+", ...), ...) and must not trigger E002

--- a/src/LLLangCompiler/HMInfer.fs
+++ b/src/LLLangCompiler/HMInfer.fs
@@ -7,19 +7,15 @@ open LLLang.Elaborator
 
 // ---- Error helpers -------------------------------------------------------
 
-let private mkErr code line col msg : LLError =
-    { Code = code; Line = line; Col = col
-      Message = sprintf "%s %d:%d %s" (code.ToString()) line col msg }
-
 /// Position-less error emitters. Unification returns errors without a
 /// source position (it doesn't see the source AST); callers that DO know
 /// the source expression later reposition the error via `repos`.
-let private e001 t1 t2 = mkErr E001 0 0 $"TypeMismatch {typeExprToStr t1} vs {typeExprToStr t2}"
-let private e002 name  = mkErr E002 0 0 $"UnboundVar {name}"
-let private e004 t1 t2 = mkErr E004 0 0 $"UnitMismatch {typeExprToStr t1} vs {typeExprToStr t2}"
-let private e005 t1 t2 = mkErr E005 0 0 $"TaggedUntaggedMismatch {typeExprToStr t1} vs {typeExprToStr t2}"
-let private e006 msg    = mkErr E006 0 0 $"MissingImpl {msg}"
-let private e008 v  t  = mkErr E008 0 0 $"OccursCheck {v} in {typeExprToStr t}"
+let private e001 t1 t2 = mkLLError E001 0 0 $"TypeMismatch {typeExprToStr t1} vs {typeExprToStr t2}"
+let private e002 name  = mkLLError E002 0 0 $"UnboundVar {name}"
+let private e004 t1 t2 = mkLLError E004 0 0 $"UnitMismatch {typeExprToStr t1} vs {typeExprToStr t2}"
+let private e005 t1 t2 = mkLLError E005 0 0 $"TaggedUntaggedMismatch {typeExprToStr t1} vs {typeExprToStr t2}"
+let private e006 msg    = mkLLError E006 0 0 $"MissingImpl {msg}"
+let private e008 v  t  = mkLLError E008 0 0 $"OccursCheck {v} in {typeExprToStr t}"
 
 /// Look up a node's source position in the PosMap side-table.
 /// Accepts `obj | null` so callers can pass the result of `box` directly
@@ -27,23 +23,12 @@ let private e008 v  t  = mkErr E008 0 0 $"OccursCheck {v} in {typeExprToStr t}"
 let private posOf (pm: PosMap) (node: obj | null) : int * int =
     PosMap.tryFind pm node |> fun p -> (p.Line, p.Col)
 
-/// Rewrite an error's line/col (and its rendered Message) to match `(ln, col)`.
-/// Used to attach a caller-supplied source position to errors produced by
-/// position-agnostic helpers like `unify`. If the error already has a
-/// non-zero line, keep it (nested errors can supply their own position).
+/// Attach a source position to an error produced by a position-agnostic helper.
+/// Rebuilds Message from Body + new position without string-parsing.
+/// If the error already has a non-zero line, keep it unchanged.
 let private repos (ln: int) (col: int) (err: LLError) : LLError =
     if err.Line <> 0 || err.Col <> 0 then err
-    else
-        // Reconstruct the Message with the new line/col. The format is
-        // "EXXX L:C Rest..." — split off the first two whitespace-separated
-        // tokens and replace the second ("L:C") with the new one.
-        let parts = err.Message.Split([| ' ' |], 3)
-        let newMsg =
-            if parts.Length >= 2 then
-                let rest = if parts.Length = 3 then " " + parts[2] else ""
-                sprintf "%s %d:%d%s" parts[0] ln col rest
-            else err.Message
-        { err with Line = ln; Col = col; Message = newMsg }
+    else mkLLError err.Code ln col err.Body
 
 // ---- Helpers -------------------------------------------------------------
 
@@ -500,7 +485,7 @@ and private patternType (st: InferState) (env: Env) (pat: Pattern) : TypeExpr * 
             let nExpected = List.length expectedArgTys
             let nActual   = List.length argPats
             if nActual > nExpected then
-                st.Errors <- st.Errors @ [mkErr E001 0 0 (sprintf "TypeMismatch constructor %s (arity %d) applied to %d argument(s)" name nExpected nActual)]
+                st.Errors <- st.Errors @ [mkLLError E001 0 0 (sprintf "TypeMismatch constructor %s (arity %d) applied to %d argument(s)" name nExpected nActual)]
             // Only zip the patterns that have a corresponding expected type;
             // extra patterns (over-application) are skipped — the error above
             // already records the problem.

--- a/src/LLLangCompiler/ProjectLoader.fs
+++ b/src/LLLangCompiler/ProjectLoader.fs
@@ -27,13 +27,11 @@ type LLProject = {
 let private e020 (filePath: string) (expected: string list) (actual: string list) : LLError =
     let exp = String.concat "." expected
     let act = String.concat "." actual
-    { Code = E020; Line = 0; Col = 0
-      Message = sprintf "E020 0:0 ModulePathMismatch file:%s expected:%s got:%s" filePath exp act }
+    mkLLError E020 0 0 (sprintf "ModulePathMismatch file:%s expected:%s got:%s" filePath exp act)
 
 let private e024 (cycle: string list) : LLError =
     let path = String.concat " -> " cycle
-    { Code = E024; Line = 0; Col = 0
-      Message = sprintf "E024 0:0 ModuleCycle %s" path }
+    mkLLError E024 0 0 (sprintf "ModuleCycle %s" path)
 
 // ---- Helpers ---------------------------------------------------------------
 
@@ -153,12 +151,12 @@ let loadProject (rootDir: string) : Result<LLProject, LLError list> =
         | None   -> Path.Combine(rootDir, "lll.toml")  // will fail with a clear message below
     let manifestSrc =
         try Ok (File.ReadAllText manifestPath)
-        with ex -> Error [{ Code = E001; Line = 0; Col = 0; Message = sprintf "E001 0:0 CannotReadManifest %s: %s" manifestPath ex.Message }]
+        with ex -> Error [mkLLError E001 0 0 (sprintf "CannotReadManifest %s: %s" manifestPath ex.Message)]
     match manifestSrc with
     | Error es -> Error es
     | Ok manifestText ->
     match parseManifest manifestText with
-    | Error msg -> Error [{ Code = E001; Line = 0; Col = 0; Message = sprintf "E001 0:0 ManifestError %s" msg }]
+    | Error msg -> Error [mkLLError E001 0 0 (sprintf "ManifestError %s" msg)]
     | Ok manifest ->
     // 2. Glob all .lll files under rootDir/src/
     let srcDir = Path.Combine(rootDir, "src")
@@ -173,18 +171,18 @@ let loadProject (rootDir: string) : Result<LLProject, LLError list> =
         let src =
             try Some (File.ReadAllText filePath)
             with ex ->
-                errors <- errors @ [{ Code = E001; Line = 0; Col = 0; Message = sprintf "E001 0:0 CannotReadFile %s: %s" filePath ex.Message }]
+                errors <- errors @ [mkLLError E001 0 0 (sprintf "CannotReadFile %s: %s" filePath ex.Message)]
                 None
         match src with
         | None -> ()
         | Some srcText ->
             match tokenize srcText with
             | Error e ->
-                errors <- errors @ [{ Code = E001; Line = 0; Col = 0; Message = sprintf "E001 0:0 LexError %s: %s" filePath e }]
+                errors <- errors @ [mkLLError E001 0 0 (sprintf "LexError %s: %s" filePath e)]
             | Ok toks ->
                 match parseModuleWithPos toks with
                 | Error e ->
-                    errors <- errors @ [{ Code = E001; Line = 0; Col = 0; Message = sprintf "E001 0:0 ParseError %s: %s" filePath e }]
+                    errors <- errors @ [mkLLError E001 0 0 (sprintf "ParseError %s: %s" filePath e)]
                 | Ok (m, _) ->
                     // 4. Validate module path matches file path
                     let expected = fileToExpectedModulePath rootDir manifest.Name filePath


### PR DESCRIPTION
## Summary

Fixes the core fragility in `repos` (HMInfer) which re-parsed `LLError.Message` strings to patch in source positions.

- Add `Body: string` field to `LLError` — the position-free detail (e.g., `"TypeMismatch Int vs Str"`) without code prefix or position
- Add `mkLLError code line col body` as the single internal constructor shared across Elaborator, HMInfer, ProjectLoader, and Compiler
- `repos` now rebuilds `Message` from structured fields (`Code`, new `Line`/`Col`, `Body`) instead of `Split([' '], 3)` string-parsing
- Remove redundant private `mkErr` in HMInfer (was byte-for-byte identical to the new `mkLLError`)
- All `{ Code = E001; Line = 0; Col = 0; Message = sprintf "E001 0:0 ..." }` inline constructions migrated to `mkLLError`

## Why this matters

The old `repos` was:
```fsharp
let parts = err.Message.Split([| ' ' |], 3)
let rest = if parts.Length = 3 then " " + parts[2] else ""
sprintf "%s %d:%d%s" parts[0] ln col rest
```
Any message body containing spaces required `Length = 3` to capture the remainder, and any format deviation (extra space, tabs) silently dropped the body. The new `repos` is:
```fsharp
mkLLError err.Code ln col err.Body
```

## Test plan
- [x] `dotnet test` — 753 passed, 0 failed, 42 skipped (identical to main)

Closes #21

🤖 Generated with [Claude Code](https://claude.ai/claude-code)