### PR TITLE
feat(site): add gh-pages documentation site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,36 @@
+name: Deploy documentation site
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs-site/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'docs-site'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,10 +1,9 @@
-name: Deploy documentation site
+name: Deploy gh-pages site
 
 on:
   push:
     branches: [main]
-    paths:
-      - 'docs-site/**'
+    paths: ['docs-site/**']
   workflow_dispatch:
 
 permissions:
@@ -23,14 +22,10 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Pages
-        uses: actions/configure-pages@v4
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v4
+      - uses: actions/upload-pages-artifact@v3
         with:
-          path: 'docs-site'
-      - name: Deploy to GitHub Pages
-        id: deployment
+          path: docs-site
+      - id: deployment
         uses: actions/deploy-pages@v4

--- a/docs-site/_config.yml
+++ b/docs-site/_config.yml
@@ -1,0 +1,16 @@
+# ll-lang gh-pages site
+# Plain HTML/CSS/JS — no Jekyll processing needed.
+# This file tells GitHub Pages not to apply a Jekyll theme.
+
+title: ll-lang
+description: The language built for LLMs to write, compile, and fix.
+url: https://neftedollar.github.io/ll-lang
+
+# Disable Jekyll theme (site is plain HTML)
+theme: ~
+
+# Exclude source files from Jekyll build
+exclude:
+  - "*.md"
+  - Gemfile
+  - Gemfile.lock

--- a/docs-site/css/style.css
+++ b/docs-site/css/style.css
@@ -1,48 +1,40 @@
 /* ll-lang docs — dark-first, minimal, monospace-forward */
 
 /* ─── Fonts ─────────────────────────────────────────────────────────────── */
-@import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Inter:wght@400;500;600;700&display=swap");
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Inter:wght@400;500;600;700&display=swap');
 
 /* ─── Tokens ─────────────────────────────────────────────────────────────── */
 :root {
-  --bg: #0d0d0f;
-  --bg-surface: #141417;
-  --bg-card: #1a1a1f;
-  --bg-code: #111114;
-  --border: #2a2a32;
+  --bg:          #0d0d0f;
+  --bg-surface:  #141417;
+  --bg-card:     #1a1a1f;
+  --bg-code:     #111114;
+  --border:      #2a2a32;
   --border-glow: #4f46e540;
 
-  --text-primary: #e8e8f0;
+  --text-primary:   #e8e8f0;
   --text-secondary: #8888a0;
-  --text-muted: #55556a;
+  --text-muted:     #55556a;
 
-  --accent: #7c6ff7; /* purple */
+  --accent:       #7c6ff7;
   --accent-light: #a89af8;
-  --green: #34d399;
-  --yellow: #fbbf24;
-  --red: #f87171;
-  --blue: #60a5fa;
+  --green:        #34d399;
+  --yellow:       #fbbf24;
+  --red:          #f87171;
+  --blue:         #60a5fa;
 
-  --font-sans: "Inter", system-ui, sans-serif;
-  --font-mono: "JetBrains Mono", "Fira Code", "Cascadia Code", monospace;
+  --font-sans: 'Inter', system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
 
   --radius: 8px;
   --radius-lg: 12px;
-  --shadow: 0 4px 24px rgba(0, 0, 0, 0.45);
+  --shadow: 0 4px 24px rgba(0,0,0,.45);
 }
 
 /* ─── Reset ──────────────────────────────────────────────────────────────── */
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-}
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
-html {
-  scroll-behavior: smooth;
-}
+html { scroll-behavior: smooth; }
 
 body {
   background: var(--bg);
@@ -54,43 +46,17 @@ body {
 }
 
 /* ─── Typography ─────────────────────────────────────────────────────────── */
-h1,
-h2,
-h3,
-h4 {
-  font-weight: 700;
-  line-height: 1.25;
-}
-h1 {
-  font-size: clamp(2.2rem, 5vw, 3.6rem);
-  letter-spacing: -0.03em;
-}
-h2 {
-  font-size: clamp(1.5rem, 3vw, 2rem);
-  letter-spacing: -0.02em;
-}
-h3 {
-  font-size: 1.15rem;
-}
+h1, h2, h3, h4 { font-weight: 700; line-height: 1.25; }
+h1 { font-size: clamp(2.2rem, 5vw, 3.6rem); letter-spacing: -.03em; }
+h2 { font-size: clamp(1.5rem, 3vw, 2rem); letter-spacing: -.02em; }
+h3 { font-size: 1.15rem; }
 
-a {
-  color: var(--accent-light);
-  text-decoration: none;
-  transition: color 0.15s;
-}
-a:hover {
-  color: #fff;
-}
+a { color: var(--accent-light); text-decoration: none; transition: color .15s; }
+a:hover { color: #fff; }
 
-p {
-  color: var(--text-secondary);
-}
+p { color: var(--text-secondary); }
 
-code,
-kbd {
-  font-family: var(--font-mono);
-  font-size: 0.85em;
-}
+code, kbd { font-family: var(--font-mono); font-size: .85em; }
 
 /* ─── Layout ─────────────────────────────────────────────────────────────── */
 .container {
@@ -99,16 +65,14 @@ kbd {
   padding-inline: clamp(1rem, 4vw, 2.5rem);
 }
 
-section {
-  padding-block: clamp(3rem, 8vw, 6rem);
-}
+section { padding-block: clamp(3rem, 8vw, 6rem); }
 
 /* ─── Nav ────────────────────────────────────────────────────────────────── */
 nav {
   position: sticky;
   top: 0;
   z-index: 100;
-  background: rgba(13, 13, 15, 0.85);
+  background: rgba(13,13,15,.85);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   border-bottom: 1px solid var(--border);
@@ -131,11 +95,9 @@ nav {
   color: var(--text-primary);
   display: flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: .4rem;
 }
-.nav-logo span {
-  color: var(--accent);
-}
+.nav-logo span { color: var(--accent); }
 
 .nav-links {
   display: flex;
@@ -146,30 +108,22 @@ nav {
 
 .nav-links a {
   color: var(--text-secondary);
-  font-size: 0.9rem;
+  font-size: .9rem;
   font-weight: 500;
-  transition: color 0.15s;
+  transition: color .15s;
 }
-.nav-links a:hover,
-.nav-links a.active {
-  color: var(--text-primary);
-}
+.nav-links a:hover, .nav-links a.active { color: var(--text-primary); }
 
 .nav-cta {
-  background: var(--accent);
+  background: var(--accent) !important;
   color: #fff !important;
-  padding: 0.35rem 0.9rem;
+  padding: .35rem .9rem;
   border-radius: var(--radius);
-  font-size: 0.85rem !important;
+  font-size: .85rem !important;
   font-weight: 600 !important;
-  transition:
-    background 0.15s,
-    transform 0.1s !important;
+  transition: background .15s, transform .1s !important;
 }
-.nav-cta:hover {
-  background: var(--accent-light) !important;
-  transform: translateY(-1px);
-}
+.nav-cta:hover { background: var(--accent-light) !important; transform: translateY(-1px); }
 
 .nav-hamburger {
   display: none;
@@ -186,7 +140,7 @@ nav {
   height: 2px;
   background: var(--text-secondary);
   border-radius: 2px;
-  transition: all 0.2s;
+  transition: all .2s;
 }
 
 /* ─── Hero ───────────────────────────────────────────────────────────────── */
@@ -198,33 +152,28 @@ nav {
 }
 
 .hero::before {
-  content: "";
+  content: '';
   position: absolute;
   inset: 0;
-  background: radial-gradient(
-    ellipse 80% 50% at 50% -20%,
-    #4f46e522 0%,
-    transparent 70%
-  );
+  background: radial-gradient(ellipse 80% 50% at 50% -20%, #4f46e522 0%, transparent 70%);
   pointer-events: none;
 }
 
 .hero-badge {
   display: inline-flex;
   align-items: center;
-  gap: 0.45rem;
+  gap: .45rem;
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: 100px;
-  padding: 0.3rem 0.85rem;
-  font-size: 0.8rem;
+  padding: .3rem .85rem;
+  font-size: .8rem;
   font-family: var(--font-mono);
   color: var(--text-secondary);
   margin-bottom: 2rem;
 }
 .hero-badge .dot {
-  width: 7px;
-  height: 7px;
+  width: 7px; height: 7px;
   border-radius: 50%;
   background: var(--green);
   box-shadow: 0 0 6px var(--green);
@@ -241,7 +190,7 @@ nav {
 }
 
 .hero-sub {
-  font-size: clamp(0.95rem, 2vw, 1.2rem);
+  font-size: clamp(.95rem, 2vw, 1.2rem);
   color: var(--text-secondary);
   max-width: 56ch;
   margin-inline: auto;
@@ -252,7 +201,7 @@ nav {
 .hero-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
+  gap: .75rem;
   justify-content: center;
   margin-bottom: 3.5rem;
 }
@@ -261,13 +210,13 @@ nav {
 .btn {
   display: inline-flex;
   align-items: center;
-  gap: 0.45rem;
-  padding: 0.65rem 1.4rem;
+  gap: .45rem;
+  padding: .65rem 1.4rem;
   border-radius: var(--radius);
-  font-size: 0.95rem;
+  font-size: .95rem;
   font-weight: 600;
   cursor: pointer;
-  transition: all 0.15s;
+  transition: all .15s;
   border: none;
   text-decoration: none;
 }
@@ -289,22 +238,14 @@ nav {
   color: var(--text-primary);
   border: 1px solid var(--border);
 }
-.btn-secondary:hover {
-  border-color: var(--accent);
-  color: var(--accent-light);
-  transform: translateY(-2px);
-}
+.btn-secondary:hover { border-color: var(--accent); color: var(--accent-light); transform: translateY(-2px); }
 
 .btn-ghost {
   background: transparent;
   color: var(--text-secondary);
   border: 1px solid var(--border);
 }
-.btn-ghost:hover {
-  color: var(--text-primary);
-  border-color: var(--text-muted);
-  transform: translateY(-2px);
-}
+.btn-ghost:hover { color: var(--text-primary); border-color: var(--text-muted); transform: translateY(-2px); }
 
 /* ─── Hero terminal mockup ───────────────────────────────────────────────── */
 .hero-terminal {
@@ -313,9 +254,7 @@ nav {
   background: var(--bg-code);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
-  box-shadow:
-    var(--shadow),
-    0 0 48px #4f46e512;
+  box-shadow: var(--shadow), 0 0 48px #4f46e512;
   text-align: left;
   overflow: hidden;
 }
@@ -323,29 +262,18 @@ nav {
 .terminal-bar {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.7rem 1rem;
+  gap: .5rem;
+  padding: .7rem 1rem;
   background: var(--bg-card);
   border-bottom: 1px solid var(--border);
 }
-.terminal-bar .dot {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-}
-.terminal-bar .dot.red {
-  background: #ff5f57;
-}
-.terminal-bar .dot.yellow {
-  background: #febc2e;
-}
-.terminal-bar .dot.green {
-  background: #28c840;
-}
+.terminal-bar .dot { width: 12px; height: 12px; border-radius: 50%; }
+.terminal-bar .dot.red    { background: #ff5f57; }
+.terminal-bar .dot.yellow { background: #febc2e; }
+.terminal-bar .dot.green  { background: #28c840; }
 .terminal-title {
-  flex: 1;
-  text-align: center;
-  font-size: 0.75rem;
+  flex: 1; text-align: center;
+  font-size: .75rem;
   font-family: var(--font-mono);
   color: var(--text-muted);
 }
@@ -353,50 +281,31 @@ nav {
 .terminal-body {
   padding: 1.25rem 1.5rem;
   font-family: var(--font-mono);
-  font-size: 0.85rem;
+  font-size: .85rem;
   line-height: 1.8;
 }
 
-.t-comment {
-  color: var(--text-muted);
-}
-.t-prompt {
-  color: var(--accent);
-}
-.t-keyword {
-  color: var(--accent-light);
-}
-.t-type {
-  color: var(--yellow);
-}
-.t-string {
-  color: var(--green);
-}
-.t-output {
-  color: var(--text-secondary);
-}
-.t-success {
-  color: var(--green);
-}
-.t-error {
-  color: var(--red);
-  font-size: 0.8rem;
-}
+.t-comment { color: var(--text-muted); }
+.t-prompt   { color: var(--accent); }
+.t-keyword  { color: var(--accent-light); }
+.t-type     { color: var(--yellow); }
+.t-string   { color: var(--green); }
+.t-output   { color: var(--text-secondary); }
+.t-success  { color: var(--green); }
+.t-error    { color: var(--red); font-size: .8rem; }
 
 /* ─── Section headings ───────────────────────────────────────────────────── */
 .section-label {
   display: inline-block;
   font-family: var(--font-mono);
-  font-size: 0.75rem;
+  font-size: .75rem;
   color: var(--accent);
-  letter-spacing: 0.1em;
+  letter-spacing: .1em;
   text-transform: uppercase;
-  margin-bottom: 0.75rem;
+  margin-bottom: .75rem;
 }
 
-.section-title {
-  margin-bottom: 0.75rem;
-}
+.section-title { margin-bottom: .75rem; }
 
 .section-sub {
   color: var(--text-secondary);
@@ -417,18 +326,12 @@ nav {
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   padding: 1.75rem;
-  transition:
-    border-color 0.2s,
-    transform 0.2s;
+  transition: border-color .2s, transform .2s;
 }
-.feature-card:hover {
-  border-color: var(--accent);
-  transform: translateY(-3px);
-}
+.feature-card:hover { border-color: var(--accent); transform: translateY(-3px); }
 
 .feature-icon {
-  width: 40px;
-  height: 40px;
+  width: 40px; height: 40px;
   border-radius: var(--radius);
   background: #4f46e520;
   display: flex;
@@ -438,16 +341,8 @@ nav {
   margin-bottom: 1rem;
 }
 
-.feature-card h3 {
-  color: var(--text-primary);
-  margin-bottom: 0.4rem;
-}
-
-.feature-card p {
-  font-size: 0.9rem;
-  margin-bottom: 1.25rem;
-  color: var(--text-secondary);
-}
+.feature-card h3 { color: var(--text-primary); margin-bottom: .4rem; }
+.feature-card p  { font-size: .9rem; margin-bottom: 1.25rem; color: var(--text-secondary); }
 
 /* ─── Code blocks ────────────────────────────────────────────────────────── */
 .code-block {
@@ -461,206 +356,108 @@ nav {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.5rem 1rem;
+  padding: .5rem 1rem;
   background: var(--bg-card);
   border-bottom: 1px solid var(--border);
 }
 
 .code-lang {
   font-family: var(--font-mono);
-  font-size: 0.7rem;
+  font-size: .7rem;
   color: var(--text-muted);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: .08em;
 }
 
 .copy-btn {
-  font-size: 0.7rem;
+  font-size: .7rem;
   font-family: var(--font-mono);
   color: var(--text-muted);
   background: none;
   border: none;
   cursor: pointer;
-  padding: 0.15rem 0.4rem;
+  padding: .15rem .4rem;
   border-radius: 4px;
-  transition:
-    color 0.15s,
-    background 0.15s;
+  transition: color .15s, background .15s;
 }
-.copy-btn:hover {
-  color: var(--text-primary);
-  background: var(--border);
-}
+.copy-btn:hover { color: var(--text-primary); background: var(--border); }
 
-.code-block pre {
-  padding: 1.1rem 1.25rem;
-  overflow-x: auto;
-  margin: 0;
-}
+.code-block pre { padding: 1.1rem 1.25rem; overflow-x: auto; margin: 0; }
+.code-block code { font-size: .82rem; line-height: 1.75; }
 
-.code-block code {
-  font-size: 0.82rem;
-  line-height: 1.75;
-}
+.hljs { background: transparent !important; }
 
-/* highlight.js theme overrides */
-.hljs {
-  background: transparent !important;
-}
-
-/* ─── Code comparison (side-by-side) ────────────────────────────────────── */
-.code-compare {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 1rem;
-}
-@media (max-width: 640px) {
-  .code-compare {
-    grid-template-columns: 1fr;
-  }
-}
+/* ─── Code comparison ────────────────────────────────────────────────────── */
+.code-compare { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+@media (max-width: 640px) { .code-compare { grid-template-columns: 1fr; } }
 
 .compare-label {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 1rem;
+  gap: .5rem;
+  padding: .5rem 1rem;
   background: var(--bg-card);
   border-bottom: 1px solid var(--border);
-  font-size: 0.72rem;
+  font-size: .72rem;
   font-family: var(--font-mono);
   color: var(--text-muted);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: .08em;
 }
 .compare-label .badge {
-  padding: 0.1rem 0.45rem;
+  padding: .1rem .45rem;
   border-radius: 4px;
-  font-size: 0.68rem;
+  font-size: .68rem;
   font-weight: 600;
 }
-.badge-before {
-  background: #f8717120;
-  color: var(--red);
-}
-.badge-after {
-  background: #34d39920;
-  color: var(--green);
-}
+.badge-before { background: #f8717120; color: var(--red); }
+.badge-after  { background: #34d39920; color: var(--green); }
 
-/* ─── Error showcase ─────────────────────────────────────────────────────── */
-.error-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 0.88rem;
-}
+/* ─── Error table ────────────────────────────────────────────────────────── */
+.error-table { width: 100%; border-collapse: collapse; font-size: .88rem; }
 .error-table th {
   text-align: left;
-  padding: 0.6rem 1rem;
+  padding: .6rem 1rem;
   background: var(--bg-card);
   color: var(--text-muted);
   font-family: var(--font-mono);
-  font-size: 0.75rem;
+  font-size: .75rem;
   text-transform: uppercase;
-  letter-spacing: 0.07em;
+  letter-spacing: .07em;
   border-bottom: 1px solid var(--border);
 }
-.error-table td {
-  padding: 0.7rem 1rem;
-  border-bottom: 1px solid var(--border);
-  color: var(--text-secondary);
-  vertical-align: top;
-}
-.error-table tr:last-child td {
-  border-bottom: none;
-}
-.error-table tr:hover td {
-  background: var(--bg-surface);
-}
-.error-code {
-  font-family: var(--font-mono);
-  font-size: 0.82rem;
-  color: var(--red);
-  white-space: nowrap;
-}
-.error-example {
-  font-family: var(--font-mono);
-  font-size: 0.78rem;
-  color: var(--text-muted);
-  white-space: nowrap;
-}
+.error-table td { padding: .7rem 1rem; border-bottom: 1px solid var(--border); color: var(--text-secondary); vertical-align: top; }
+.error-table tr:last-child td { border-bottom: none; }
+.error-table tr:hover td { background: var(--bg-surface); }
+.error-code    { font-family: var(--font-mono); font-size: .82rem; color: var(--red); white-space: nowrap; }
+.error-example { font-family: var(--font-mono); font-size: .78rem; color: var(--text-muted); white-space: nowrap; }
 
 /* ─── Targets grid ───────────────────────────────────────────────────────── */
-.targets-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: 1rem;
-}
+.targets-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(130px, 1fr)); gap: 1rem; }
 
 .target-card {
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  padding: 1.1rem;
+  padding: 1rem;
   text-align: center;
-  transition:
-    border-color 0.2s,
-    transform 0.2s;
+  transition: border-color .2s, transform .2s;
 }
-.target-card:hover {
-  border-color: var(--accent);
-  transform: translateY(-2px);
-}
-.target-card .t-icon {
-  font-size: 1.75rem;
-  margin-bottom: 0.5rem;
-}
-.target-card .t-name {
-  font-family: var(--font-mono);
-  font-size: 0.8rem;
-  color: var(--text-primary);
-  font-weight: 600;
-}
-.target-card .t-flag {
-  font-family: var(--font-mono);
-  font-size: 0.72rem;
-  color: var(--text-muted);
-  margin-top: 0.2rem;
-}
-.target-card .t-stable {
-  display: inline-block;
-  font-size: 0.65rem;
-  padding: 0.1rem 0.35rem;
-  border-radius: 4px;
-  margin-top: 0.35rem;
-  font-weight: 600;
-}
-.stable {
-  background: #34d39920;
-  color: var(--green);
-}
-.experimental {
-  background: #fbbf2420;
-  color: var(--yellow);
-}
+.target-card:hover { border-color: var(--accent); transform: translateY(-2px); }
+.target-card .t-icon  { font-size: 1.75rem; margin-bottom: .5rem; }
+.target-card .t-name  { font-family: var(--font-mono); font-size: .8rem; color: var(--text-primary); font-weight: 600; }
+.target-card .t-flag  { font-family: var(--font-mono); font-size: .72rem; color: var(--text-muted); margin-top: .2rem; }
+.target-card .t-stable { display: inline-block; font-size: .65rem; padding: .1rem .35rem; border-radius: 4px; margin-top: .35rem; font-weight: 600; }
+.stable       { background: #34d39920; color: var(--green); }
+.experimental { background: #fbbf2420; color: var(--yellow); }
 
-/* ─── Quickstart / Steps ─────────────────────────────────────────────────── */
-.quickstart-steps {
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-}
+/* ─── Quickstart steps ───────────────────────────────────────────────────── */
+.quickstart-steps { display: flex; flex-direction: column; gap: 1.5rem; }
 
-.qs-step {
-  display: grid;
-  grid-template-columns: 2.5rem 1fr;
-  gap: 1.25rem;
-  align-items: start;
-}
+.qs-step { display: grid; grid-template-columns: 2.5rem 1fr; gap: 1.25rem; align-items: start; }
 
 .qs-num {
-  width: 2.5rem;
-  height: 2.5rem;
+  width: 2.5rem; height: 2.5rem;
   border-radius: 50%;
   background: #4f46e520;
   border: 1px solid var(--border);
@@ -668,18 +465,14 @@ nav {
   align-items: center;
   justify-content: center;
   font-family: var(--font-mono);
-  font-size: 0.85rem;
+  font-size: .85rem;
   color: var(--accent);
   font-weight: 600;
   flex-shrink: 0;
-  margin-top: 0.1rem;
+  margin-top: .1rem;
 }
 
-.qs-content h3 {
-  color: var(--text-primary);
-  margin-bottom: 0.6rem;
-  font-size: 1rem;
-}
+.qs-content h3 { color: var(--text-primary); margin-bottom: .6rem; font-size: 1rem; }
 
 /* ─── Stats bar ──────────────────────────────────────────────────────────── */
 .stats-bar {
@@ -692,31 +485,20 @@ nav {
   border-radius: var(--radius-lg);
 }
 
-.stat-item {
-  text-align: center;
-}
+.stat-item { text-align: center; }
 .stat-value {
   font-size: 2rem;
   font-weight: 700;
   font-family: var(--font-mono);
-  color: var(--text-primary);
   background: linear-gradient(135deg, #fff 20%, var(--accent-light));
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
 }
-.stat-label {
-  font-size: 0.8rem;
-  color: var(--text-muted);
-  margin-top: 0.15rem;
-}
+.stat-label { font-size: .8rem; color: var(--text-muted); margin-top: .15rem; }
 
 /* ─── Community links ────────────────────────────────────────────────────── */
-.links-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1rem;
-}
+.links-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem; }
 
 .link-card {
   display: flex;
@@ -728,97 +510,46 @@ nav {
   padding: 1.1rem 1.25rem;
   text-decoration: none;
   color: var(--text-primary);
-  transition:
-    border-color 0.2s,
-    transform 0.2s;
+  transition: border-color .2s, transform .2s;
 }
-.link-card:hover {
-  border-color: var(--accent);
-  transform: translateY(-2px);
-  color: var(--text-primary);
-}
-.link-card .l-icon {
-  font-size: 1.4rem;
-  flex-shrink: 0;
-}
-.link-card .l-title {
-  font-weight: 600;
-  font-size: 0.95rem;
-  margin-bottom: 0.1rem;
-}
-.link-card .l-desc {
-  font-size: 0.8rem;
-  color: var(--text-muted);
-}
+.link-card:hover { border-color: var(--accent); transform: translateY(-2px); color: var(--text-primary); }
+.link-card .l-icon  { font-size: 1.4rem; flex-shrink: 0; }
+.link-card .l-title { font-weight: 600; font-size: .95rem; margin-bottom: .1rem; }
+.link-card .l-desc  { font-size: .8rem; color: var(--text-muted); }
 
-/* ─── Docs page ──────────────────────────────────────────────────────────── */
-.docs-layout {
-  display: grid;
-  grid-template-columns: 220px 1fr;
-  gap: 2.5rem;
-  align-items: start;
-  padding-block: 3rem;
-}
-@media (max-width: 768px) {
-  .docs-layout {
-    grid-template-columns: 1fr;
-  }
-}
+/* ─── Docs layout ────────────────────────────────────────────────────────── */
+.docs-layout { display: grid; grid-template-columns: 220px 1fr; gap: 2.5rem; align-items: start; padding-block: 3rem; }
+@media (max-width: 768px) { .docs-layout { grid-template-columns: 1fr; } }
 
-.docs-sidebar {
-  position: sticky;
-  top: 72px;
-}
+.docs-sidebar { position: sticky; top: 72px; }
 
-.sidebar-section {
-  margin-bottom: 1.5rem;
-}
+.sidebar-section { margin-bottom: 1.5rem; }
 .sidebar-section-title {
-  font-size: 0.7rem;
+  font-size: .7rem;
   font-family: var(--font-mono);
   color: var(--text-muted);
   text-transform: uppercase;
-  letter-spacing: 0.1em;
-  margin-bottom: 0.5rem;
-  padding: 0 0.75rem;
+  letter-spacing: .1em;
+  margin-bottom: .5rem;
+  padding: 0 .75rem;
 }
-.sidebar-links {
-  list-style: none;
-}
+.sidebar-links { list-style: none; }
 .sidebar-links a {
   display: block;
-  padding: 0.35rem 0.75rem;
+  padding: .35rem .75rem;
   color: var(--text-secondary);
-  font-size: 0.88rem;
+  font-size: .88rem;
   border-radius: 6px;
-  transition:
-    background 0.15s,
-    color 0.15s;
+  transition: background .15s, color .15s;
 }
-.sidebar-links a:hover {
-  background: var(--bg-card);
-  color: var(--text-primary);
-}
-.sidebar-links a.active {
-  background: #4f46e515;
-  color: var(--accent-light);
-}
+.sidebar-links a:hover { background: var(--bg-card); color: var(--text-primary); }
+.sidebar-links a.active { background: #4f46e515; color: var(--accent-light); }
 
-.docs-content h2 {
-  font-size: 1.5rem;
-  margin-bottom: 0.5rem;
-}
-.docs-content p {
-  margin-bottom: 1rem;
-}
+.docs-content h2 { font-size: 1.5rem; margin-bottom: .5rem; }
+.docs-content p  { margin-bottom: 1rem; }
 
-/* ─── Docs cards (hub) ───────────────────────────────────────────────────── */
-.docs-cards {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-  gap: 1rem;
-  margin-top: 1.5rem;
-}
+/* ─── Doc cards ──────────────────────────────────────────────────────────── */
+.docs-cards { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 1rem; margin-top: 1.5rem; }
 
 .doc-card {
   background: var(--bg-card);
@@ -827,35 +558,15 @@ nav {
   padding: 1.25rem;
   text-decoration: none;
   color: var(--text-primary);
-  transition:
-    border-color 0.2s,
-    transform 0.2s;
+  transition: border-color .2s, transform .2s;
   display: block;
 }
-.doc-card:hover {
-  border-color: var(--accent);
-  transform: translateY(-2px);
-  color: var(--text-primary);
-}
-.doc-card-icon {
-  font-size: 1.5rem;
-  margin-bottom: 0.6rem;
-}
-.doc-card h3 {
-  font-size: 1rem;
-  margin-bottom: 0.3rem;
-}
-.doc-card p {
-  font-size: 0.85rem;
-  color: var(--text-muted);
-}
+.doc-card:hover { border-color: var(--accent); transform: translateY(-2px); color: var(--text-primary); }
+.doc-card-icon { font-size: 1.5rem; margin-bottom: .6rem; }
+.doc-card h3 { font-size: 1rem; margin-bottom: .3rem; }
+.doc-card p  { font-size: .85rem; color: var(--text-muted); }
 
-/* ─── Playground page ────────────────────────────────────────────────────── */
-.playground-hero {
-  padding-block: 4rem;
-  text-align: center;
-}
-
+/* ─── Coming soon card ───────────────────────────────────────────────────── */
 .coming-soon-card {
   max-width: 540px;
   margin-inline: auto;
@@ -863,25 +574,17 @@ nav {
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   padding: 3rem 2rem;
+  text-align: center;
 }
-.coming-soon-card .icon {
-  font-size: 3rem;
-  margin-bottom: 1.5rem;
-}
-.coming-soon-card h2 {
-  margin-bottom: 0.75rem;
-  font-size: 1.6rem;
-}
-.coming-soon-card p {
-  margin-bottom: 1.5rem;
-}
+.coming-soon-card .icon { font-size: 3rem; margin-bottom: 1.5rem; }
+.coming-soon-card h2   { margin-bottom: .75rem; font-size: 1.6rem; }
+.coming-soon-card p    { margin-bottom: 1.5rem; }
+
+/* ─── Divider ────────────────────────────────────────────────────────────── */
+.divider { height: 1px; background: var(--border); margin-block: 0; }
 
 /* ─── Footer ─────────────────────────────────────────────────────────────── */
-footer {
-  border-top: 1px solid var(--border);
-  padding-block: 2.5rem;
-  margin-top: 4rem;
-}
+footer { border-top: 1px solid var(--border); padding-block: 2.5rem; margin-top: 4rem; }
 .footer-inner {
   display: flex;
   flex-wrap: wrap;
@@ -892,80 +595,17 @@ footer {
   margin-inline: auto;
   padding-inline: clamp(1rem, 4vw, 2.5rem);
 }
-.footer-logo {
-  font-family: var(--font-mono);
-  font-size: 0.95rem;
-  font-weight: 600;
-  color: var(--text-secondary);
-}
-.footer-logo span {
-  color: var(--accent);
-}
-.footer-links {
-  display: flex;
-  gap: 1.5rem;
-  list-style: none;
-}
-.footer-links a {
-  color: var(--text-muted);
-  font-size: 0.85rem;
-  transition: color 0.15s;
-}
-.footer-links a:hover {
-  color: var(--text-secondary);
-}
-.footer-copy {
-  color: var(--text-muted);
-  font-size: 0.8rem;
-  width: 100%;
-  text-align: center;
-  margin-top: 0.75rem;
-}
-
-/* ─── Utility ────────────────────────────────────────────────────────────── */
-.divider {
-  height: 1px;
-  background: var(--border);
-  margin-block: 0;
-}
-
-.text-accent {
-  color: var(--accent-light);
-}
-.text-mono {
-  font-family: var(--font-mono);
-}
-
-.pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.3rem;
-  padding: 0.2rem 0.6rem;
-  border-radius: 100px;
-  font-size: 0.75rem;
-  font-family: var(--font-mono);
-  font-weight: 600;
-  border: 1px solid;
-}
-.pill-purple {
-  background: #4f46e520;
-  border-color: #4f46e540;
-  color: var(--accent-light);
-}
-.pill-green {
-  background: #34d39920;
-  border-color: #34d39940;
-  color: var(--green);
-}
+.footer-logo { font-family: var(--font-mono); font-size: .95rem; font-weight: 600; color: var(--text-secondary); }
+.footer-logo span { color: var(--accent); }
+.footer-links { display: flex; gap: 1.5rem; list-style: none; }
+.footer-links a { color: var(--text-muted); font-size: .85rem; transition: color .15s; }
+.footer-links a:hover { color: var(--text-secondary); }
+.footer-copy { color: var(--text-muted); font-size: .8rem; width: 100%; text-align: center; margin-top: .75rem; }
 
 /* ─── Mobile ─────────────────────────────────────────────────────────────── */
 @media (max-width: 768px) {
-  .nav-links {
-    display: none;
-  }
-  .nav-hamburger {
-    display: flex;
-  }
+  .nav-links { display: none; }
+  .nav-hamburger { display: flex; }
   .nav-links.open {
     display: flex;
     flex-direction: column;
@@ -977,10 +617,6 @@ footer {
     border-top: 1px solid var(--border);
     z-index: 99;
   }
-  .features-grid {
-    grid-template-columns: 1fr;
-  }
-  .stats-bar {
-    grid-template-columns: 1fr 1fr;
-  }
+  .features-grid { grid-template-columns: 1fr; }
+  .stats-bar     { grid-template-columns: 1fr 1fr; }
 }

--- a/docs-site/css/style.css
+++ b/docs-site/css/style.css
@@ -1,0 +1,986 @@
+/* ll-lang docs — dark-first, minimal, monospace-forward */
+
+/* ─── Fonts ─────────────────────────────────────────────────────────────── */
+@import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Inter:wght@400;500;600;700&display=swap");
+
+/* ─── Tokens ─────────────────────────────────────────────────────────────── */
+:root {
+  --bg: #0d0d0f;
+  --bg-surface: #141417;
+  --bg-card: #1a1a1f;
+  --bg-code: #111114;
+  --border: #2a2a32;
+  --border-glow: #4f46e540;
+
+  --text-primary: #e8e8f0;
+  --text-secondary: #8888a0;
+  --text-muted: #55556a;
+
+  --accent: #7c6ff7; /* purple */
+  --accent-light: #a89af8;
+  --green: #34d399;
+  --yellow: #fbbf24;
+  --red: #f87171;
+  --blue: #60a5fa;
+
+  --font-sans: "Inter", system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", "Fira Code", "Cascadia Code", monospace;
+
+  --radius: 8px;
+  --radius-lg: 12px;
+  --shadow: 0 4px 24px rgba(0, 0, 0, 0.45);
+}
+
+/* ─── Reset ──────────────────────────────────────────────────────────────── */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  font-size: 16px;
+  line-height: 1.65;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* ─── Typography ─────────────────────────────────────────────────────────── */
+h1,
+h2,
+h3,
+h4 {
+  font-weight: 700;
+  line-height: 1.25;
+}
+h1 {
+  font-size: clamp(2.2rem, 5vw, 3.6rem);
+  letter-spacing: -0.03em;
+}
+h2 {
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  letter-spacing: -0.02em;
+}
+h3 {
+  font-size: 1.15rem;
+}
+
+a {
+  color: var(--accent-light);
+  text-decoration: none;
+  transition: color 0.15s;
+}
+a:hover {
+  color: #fff;
+}
+
+p {
+  color: var(--text-secondary);
+}
+
+code,
+kbd {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+}
+
+/* ─── Layout ─────────────────────────────────────────────────────────────── */
+.container {
+  max-width: 1100px;
+  margin-inline: auto;
+  padding-inline: clamp(1rem, 4vw, 2.5rem);
+}
+
+section {
+  padding-block: clamp(3rem, 8vw, 6rem);
+}
+
+/* ─── Nav ────────────────────────────────────────────────────────────────── */
+nav {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: rgba(13, 13, 15, 0.85);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--border);
+}
+
+.nav-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 56px;
+  max-width: 1100px;
+  margin-inline: auto;
+  padding-inline: clamp(1rem, 4vw, 2.5rem);
+}
+
+.nav-logo {
+  font-family: var(--font-mono);
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.nav-logo span {
+  color: var(--accent);
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 1.75rem;
+  list-style: none;
+}
+
+.nav-links a {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  font-weight: 500;
+  transition: color 0.15s;
+}
+.nav-links a:hover,
+.nav-links a.active {
+  color: var(--text-primary);
+}
+
+.nav-cta {
+  background: var(--accent);
+  color: #fff !important;
+  padding: 0.35rem 0.9rem;
+  border-radius: var(--radius);
+  font-size: 0.85rem !important;
+  font-weight: 600 !important;
+  transition:
+    background 0.15s,
+    transform 0.1s !important;
+}
+.nav-cta:hover {
+  background: var(--accent-light) !important;
+  transform: translateY(-1px);
+}
+
+.nav-hamburger {
+  display: none;
+  flex-direction: column;
+  gap: 5px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+}
+.nav-hamburger span {
+  display: block;
+  width: 22px;
+  height: 2px;
+  background: var(--text-secondary);
+  border-radius: 2px;
+  transition: all 0.2s;
+}
+
+/* ─── Hero ───────────────────────────────────────────────────────────────── */
+.hero {
+  padding-block: clamp(4rem, 10vw, 8rem) clamp(3rem, 8vw, 6rem);
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    ellipse 80% 50% at 50% -20%,
+    #4f46e522 0%,
+    transparent 70%
+  );
+  pointer-events: none;
+}
+
+.hero-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 100px;
+  padding: 0.3rem 0.85rem;
+  font-size: 0.8rem;
+  font-family: var(--font-mono);
+  color: var(--text-secondary);
+  margin-bottom: 2rem;
+}
+.hero-badge .dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--green);
+  box-shadow: 0 0 6px var(--green);
+}
+
+.hero h1 {
+  max-width: 14ch;
+  margin-inline: auto;
+  margin-bottom: 1.25rem;
+  background: linear-gradient(135deg, #fff 30%, var(--accent-light) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.hero-sub {
+  font-size: clamp(0.95rem, 2vw, 1.2rem);
+  color: var(--text-secondary);
+  max-width: 56ch;
+  margin-inline: auto;
+  margin-bottom: 2.5rem;
+  line-height: 1.7;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+  margin-bottom: 3.5rem;
+}
+
+/* ─── Buttons ────────────────────────────────────────────────────────────── */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.65rem 1.4rem;
+  border-radius: var(--radius);
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s;
+  border: none;
+  text-decoration: none;
+}
+
+.btn-primary {
+  background: var(--accent);
+  color: #fff;
+  box-shadow: 0 0 24px var(--border-glow);
+}
+.btn-primary:hover {
+  background: var(--accent-light);
+  color: #fff;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 32px #7c6ff750;
+}
+
+.btn-secondary {
+  background: var(--bg-card);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+}
+.btn-secondary:hover {
+  border-color: var(--accent);
+  color: var(--accent-light);
+  transform: translateY(-2px);
+}
+
+.btn-ghost {
+  background: transparent;
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+}
+.btn-ghost:hover {
+  color: var(--text-primary);
+  border-color: var(--text-muted);
+  transform: translateY(-2px);
+}
+
+/* ─── Hero terminal mockup ───────────────────────────────────────────────── */
+.hero-terminal {
+  max-width: 560px;
+  margin-inline: auto;
+  background: var(--bg-code);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow:
+    var(--shadow),
+    0 0 48px #4f46e512;
+  text-align: left;
+  overflow: hidden;
+}
+
+.terminal-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.7rem 1rem;
+  background: var(--bg-card);
+  border-bottom: 1px solid var(--border);
+}
+.terminal-bar .dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+.terminal-bar .dot.red {
+  background: #ff5f57;
+}
+.terminal-bar .dot.yellow {
+  background: #febc2e;
+}
+.terminal-bar .dot.green {
+  background: #28c840;
+}
+.terminal-title {
+  flex: 1;
+  text-align: center;
+  font-size: 0.75rem;
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+}
+
+.terminal-body {
+  padding: 1.25rem 1.5rem;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  line-height: 1.8;
+}
+
+.t-comment {
+  color: var(--text-muted);
+}
+.t-prompt {
+  color: var(--accent);
+}
+.t-keyword {
+  color: var(--accent-light);
+}
+.t-type {
+  color: var(--yellow);
+}
+.t-string {
+  color: var(--green);
+}
+.t-output {
+  color: var(--text-secondary);
+}
+.t-success {
+  color: var(--green);
+}
+.t-error {
+  color: var(--red);
+  font-size: 0.8rem;
+}
+
+/* ─── Section headings ───────────────────────────────────────────────────── */
+.section-label {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--accent);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  margin-bottom: 0.75rem;
+}
+
+.section-title {
+  margin-bottom: 0.75rem;
+}
+
+.section-sub {
+  color: var(--text-secondary);
+  font-size: 1.05rem;
+  max-width: 52ch;
+  margin-bottom: 3rem;
+}
+
+/* ─── Features ───────────────────────────────────────────────────────────── */
+.features-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.5rem;
+}
+
+.feature-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 1.75rem;
+  transition:
+    border-color 0.2s,
+    transform 0.2s;
+}
+.feature-card:hover {
+  border-color: var(--accent);
+  transform: translateY(-3px);
+}
+
+.feature-icon {
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius);
+  background: #4f46e520;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  margin-bottom: 1rem;
+}
+
+.feature-card h3 {
+  color: var(--text-primary);
+  margin-bottom: 0.4rem;
+}
+
+.feature-card p {
+  font-size: 0.9rem;
+  margin-bottom: 1.25rem;
+  color: var(--text-secondary);
+}
+
+/* ─── Code blocks ────────────────────────────────────────────────────────── */
+.code-block {
+  background: var(--bg-code);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.code-block-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+  background: var(--bg-card);
+  border-bottom: 1px solid var(--border);
+}
+
+.code-lang {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.copy-btn {
+  font-size: 0.7rem;
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  transition:
+    color 0.15s,
+    background 0.15s;
+}
+.copy-btn:hover {
+  color: var(--text-primary);
+  background: var(--border);
+}
+
+.code-block pre {
+  padding: 1.1rem 1.25rem;
+  overflow-x: auto;
+  margin: 0;
+}
+
+.code-block code {
+  font-size: 0.82rem;
+  line-height: 1.75;
+}
+
+/* highlight.js theme overrides */
+.hljs {
+  background: transparent !important;
+}
+
+/* ─── Code comparison (side-by-side) ────────────────────────────────────── */
+.code-compare {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+@media (max-width: 640px) {
+  .code-compare {
+    grid-template-columns: 1fr;
+  }
+}
+
+.compare-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  background: var(--bg-card);
+  border-bottom: 1px solid var(--border);
+  font-size: 0.72rem;
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.compare-label .badge {
+  padding: 0.1rem 0.45rem;
+  border-radius: 4px;
+  font-size: 0.68rem;
+  font-weight: 600;
+}
+.badge-before {
+  background: #f8717120;
+  color: var(--red);
+}
+.badge-after {
+  background: #34d39920;
+  color: var(--green);
+}
+
+/* ─── Error showcase ─────────────────────────────────────────────────────── */
+.error-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.88rem;
+}
+.error-table th {
+  text-align: left;
+  padding: 0.6rem 1rem;
+  background: var(--bg-card);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  border-bottom: 1px solid var(--border);
+}
+.error-table td {
+  padding: 0.7rem 1rem;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-secondary);
+  vertical-align: top;
+}
+.error-table tr:last-child td {
+  border-bottom: none;
+}
+.error-table tr:hover td {
+  background: var(--bg-surface);
+}
+.error-code {
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  color: var(--red);
+  white-space: nowrap;
+}
+.error-example {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+/* ─── Targets grid ───────────────────────────────────────────────────────── */
+.targets-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+}
+
+.target-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.1rem;
+  text-align: center;
+  transition:
+    border-color 0.2s,
+    transform 0.2s;
+}
+.target-card:hover {
+  border-color: var(--accent);
+  transform: translateY(-2px);
+}
+.target-card .t-icon {
+  font-size: 1.75rem;
+  margin-bottom: 0.5rem;
+}
+.target-card .t-name {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--text-primary);
+  font-weight: 600;
+}
+.target-card .t-flag {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  margin-top: 0.2rem;
+}
+.target-card .t-stable {
+  display: inline-block;
+  font-size: 0.65rem;
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+  margin-top: 0.35rem;
+  font-weight: 600;
+}
+.stable {
+  background: #34d39920;
+  color: var(--green);
+}
+.experimental {
+  background: #fbbf2420;
+  color: var(--yellow);
+}
+
+/* ─── Quickstart / Steps ─────────────────────────────────────────────────── */
+.quickstart-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.qs-step {
+  display: grid;
+  grid-template-columns: 2.5rem 1fr;
+  gap: 1.25rem;
+  align-items: start;
+}
+
+.qs-num {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  background: #4f46e520;
+  border: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  color: var(--accent);
+  font-weight: 600;
+  flex-shrink: 0;
+  margin-top: 0.1rem;
+}
+
+.qs-content h3 {
+  color: var(--text-primary);
+  margin-bottom: 0.6rem;
+  font-size: 1rem;
+}
+
+/* ─── Stats bar ──────────────────────────────────────────────────────────── */
+.stats-bar {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  padding: 2rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+}
+
+.stat-item {
+  text-align: center;
+}
+.stat-value {
+  font-size: 2rem;
+  font-weight: 700;
+  font-family: var(--font-mono);
+  color: var(--text-primary);
+  background: linear-gradient(135deg, #fff 20%, var(--accent-light));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+.stat-label {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-top: 0.15rem;
+}
+
+/* ─── Community links ────────────────────────────────────────────────────── */
+.links-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.link-card {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.1rem 1.25rem;
+  text-decoration: none;
+  color: var(--text-primary);
+  transition:
+    border-color 0.2s,
+    transform 0.2s;
+}
+.link-card:hover {
+  border-color: var(--accent);
+  transform: translateY(-2px);
+  color: var(--text-primary);
+}
+.link-card .l-icon {
+  font-size: 1.4rem;
+  flex-shrink: 0;
+}
+.link-card .l-title {
+  font-weight: 600;
+  font-size: 0.95rem;
+  margin-bottom: 0.1rem;
+}
+.link-card .l-desc {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+/* ─── Docs page ──────────────────────────────────────────────────────────── */
+.docs-layout {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: 2.5rem;
+  align-items: start;
+  padding-block: 3rem;
+}
+@media (max-width: 768px) {
+  .docs-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.docs-sidebar {
+  position: sticky;
+  top: 72px;
+}
+
+.sidebar-section {
+  margin-bottom: 1.5rem;
+}
+.sidebar-section-title {
+  font-size: 0.7rem;
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-bottom: 0.5rem;
+  padding: 0 0.75rem;
+}
+.sidebar-links {
+  list-style: none;
+}
+.sidebar-links a {
+  display: block;
+  padding: 0.35rem 0.75rem;
+  color: var(--text-secondary);
+  font-size: 0.88rem;
+  border-radius: 6px;
+  transition:
+    background 0.15s,
+    color 0.15s;
+}
+.sidebar-links a:hover {
+  background: var(--bg-card);
+  color: var(--text-primary);
+}
+.sidebar-links a.active {
+  background: #4f46e515;
+  color: var(--accent-light);
+}
+
+.docs-content h2 {
+  font-size: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+.docs-content p {
+  margin-bottom: 1rem;
+}
+
+/* ─── Docs cards (hub) ───────────────────────────────────────────────────── */
+.docs-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.doc-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.25rem;
+  text-decoration: none;
+  color: var(--text-primary);
+  transition:
+    border-color 0.2s,
+    transform 0.2s;
+  display: block;
+}
+.doc-card:hover {
+  border-color: var(--accent);
+  transform: translateY(-2px);
+  color: var(--text-primary);
+}
+.doc-card-icon {
+  font-size: 1.5rem;
+  margin-bottom: 0.6rem;
+}
+.doc-card h3 {
+  font-size: 1rem;
+  margin-bottom: 0.3rem;
+}
+.doc-card p {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+/* ─── Playground page ────────────────────────────────────────────────────── */
+.playground-hero {
+  padding-block: 4rem;
+  text-align: center;
+}
+
+.coming-soon-card {
+  max-width: 540px;
+  margin-inline: auto;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 3rem 2rem;
+}
+.coming-soon-card .icon {
+  font-size: 3rem;
+  margin-bottom: 1.5rem;
+}
+.coming-soon-card h2 {
+  margin-bottom: 0.75rem;
+  font-size: 1.6rem;
+}
+.coming-soon-card p {
+  margin-bottom: 1.5rem;
+}
+
+/* ─── Footer ─────────────────────────────────────────────────────────────── */
+footer {
+  border-top: 1px solid var(--border);
+  padding-block: 2.5rem;
+  margin-top: 4rem;
+}
+.footer-inner {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  max-width: 1100px;
+  margin-inline: auto;
+  padding-inline: clamp(1rem, 4vw, 2.5rem);
+}
+.footer-logo {
+  font-family: var(--font-mono);
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+.footer-logo span {
+  color: var(--accent);
+}
+.footer-links {
+  display: flex;
+  gap: 1.5rem;
+  list-style: none;
+}
+.footer-links a {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  transition: color 0.15s;
+}
+.footer-links a:hover {
+  color: var(--text-secondary);
+}
+.footer-copy {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  width: 100%;
+  text-align: center;
+  margin-top: 0.75rem;
+}
+
+/* ─── Utility ────────────────────────────────────────────────────────────── */
+.divider {
+  height: 1px;
+  background: var(--border);
+  margin-block: 0;
+}
+
+.text-accent {
+  color: var(--accent-light);
+}
+.text-mono {
+  font-family: var(--font-mono);
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 100px;
+  font-size: 0.75rem;
+  font-family: var(--font-mono);
+  font-weight: 600;
+  border: 1px solid;
+}
+.pill-purple {
+  background: #4f46e520;
+  border-color: #4f46e540;
+  color: var(--accent-light);
+}
+.pill-green {
+  background: #34d39920;
+  border-color: #34d39940;
+  color: var(--green);
+}
+
+/* ─── Mobile ─────────────────────────────────────────────────────────────── */
+@media (max-width: 768px) {
+  .nav-links {
+    display: none;
+  }
+  .nav-hamburger {
+    display: flex;
+  }
+  .nav-links.open {
+    display: flex;
+    flex-direction: column;
+    position: fixed;
+    inset: 56px 0 0;
+    background: var(--bg);
+    padding: 2rem;
+    gap: 1.25rem;
+    border-top: 1px solid var(--border);
+    z-index: 99;
+  }
+  .features-grid {
+    grid-template-columns: 1fr;
+  }
+  .stats-bar {
+    grid-template-columns: 1fr 1fr;
+  }
+}

--- a/docs-site/docs.html
+++ b/docs-site/docs.html
@@ -1,0 +1,221 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="ll-lang documentation — language spec, stdlib reference, LLM best practices, error codes, and more.">
+  <title>ll-lang — Documentation</title>
+  <link rel="stylesheet" href="css/style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+
+  <!-- ── Nav ──────────────────────────────────────────────────────────────── -->
+  <nav>
+    <div class="nav-inner">
+      <a href="index.html" class="nav-logo"><span>//</span>ll-lang</a>
+      <ul class="nav-links" id="nav-links">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="docs.html">Docs</a></li>
+        <li><a href="playground.html">Playground</a></li>
+        <li><a href="https://github.com/Neftedollar/ll-lang" target="_blank" rel="noopener">GitHub</a></li>
+        <li>
+          <a href="https://github.com/Neftedollar/ll-lang/releases" class="nav-cta" target="_blank" rel="noopener">v1.0.0</a>
+        </li>
+      </ul>
+      <button class="nav-hamburger" id="nav-hamburger" aria-label="Toggle navigation" aria-expanded="false">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
+  </nav>
+
+  <!-- ── Docs layout ───────────────────────────────────────────────────────── -->
+  <div class="container">
+    <div class="docs-layout">
+
+      <!-- Sidebar -->
+      <aside class="docs-sidebar">
+        <div class="sidebar-section">
+          <div class="sidebar-section-title">Getting Started</div>
+          <ul class="sidebar-links">
+            <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/docs/getting-started.md" target="_blank" rel="noopener">Getting started</a></li>
+            <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/01-installation.md" target="_blank" rel="noopener">Installation</a></li>
+            <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/02-syntax.md" target="_blank" rel="noopener">Syntax overview</a></li>
+          </ul>
+        </div>
+        <div class="sidebar-section">
+          <div class="sidebar-section-title">Language Guide</div>
+          <ul class="sidebar-links">
+            <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/docs/language-spec.md" target="_blank" rel="noopener">Language spec</a></li>
+            <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/03-types-and-inference.md" target="_blank" rel="noopener">Types &amp; inference</a></li>
+            <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/04-tags-and-units.md" target="_blank" rel="noopener">Tags &amp; units</a></li>
+            <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/05-traits.md" target="_blank" rel="noopener">Traits</a></li>
+            <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/06-modules.md" target="_blank" rel="noopener">Modules</a></li>
+          </ul>
+        </div>
+        <div class="sidebar-section">
+          <div class="sidebar-section-title">Reference</div>
+          <ul class="sidebar-links">
+            <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/docs/stdlib-reference.md" target="_blank" rel="noopener">Stdlib reference</a></li>
+            <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/spec/error-codes.md" target="_blank" rel="noopener">Error codes</a></li>
+            <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/spec/grammar.ebnf" target="_blank" rel="noopener">Grammar (EBNF)</a></li>
+            <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/08-cli.md" target="_blank" rel="noopener">CLI reference</a></li>
+          </ul>
+        </div>
+        <div class="sidebar-section">
+          <div class="sidebar-section-title">LLM Integration</div>
+          <ul class="sidebar-links">
+            <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/docs/llm-best-practices.md" target="_blank" rel="noopener">LLM best practices</a></li>
+            <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/09-mcp.md" target="_blank" rel="noopener">MCP server</a></li>
+            <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/09-llm-prompting.md" target="_blank" rel="noopener">LLM prompting</a></li>
+          </ul>
+        </div>
+        <div class="sidebar-section">
+          <div class="sidebar-section-title">Targets</div>
+          <ul class="sidebar-links">
+            <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/10-targets.md" target="_blank" rel="noopener">Codegen targets</a></li>
+            <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/11-java-target.md" target="_blank" rel="noopener">Java target</a></li>
+          </ul>
+        </div>
+      </aside>
+
+      <!-- Main content -->
+      <main class="docs-content">
+        <span class="section-label">Documentation</span>
+        <h2>ll-lang docs</h2>
+        <p>
+          Browse the guides below or jump straight to a topic using the sidebar.
+          All docs live in the repository and open on GitHub.
+        </p>
+
+        <!-- Getting Started -->
+        <h3 style="margin-top: 2.5rem; margin-bottom: 1rem; color: var(--text-primary)">Getting started</h3>
+        <div class="docs-cards">
+          <a class="doc-card" href="https://github.com/Neftedollar/ll-lang/blob/main/docs/getting-started.md" target="_blank" rel="noopener">
+            <div class="doc-card-icon">&#x1F680;</div>
+            <h3>Getting started</h3>
+            <p>Install, write your first program, compile to F# in 5 minutes.</p>
+          </a>
+          <a class="doc-card" href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/01-installation.md" target="_blank" rel="noopener">
+            <div class="doc-card-icon">&#x2699;&#xFE0F;</div>
+            <h3>Installation</h3>
+            <p>Build from source, .NET 10 setup, environment check.</p>
+          </a>
+          <a class="doc-card" href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/02-syntax.md" target="_blank" rel="noopener">
+            <div class="doc-card-icon">&#x270F;&#xFE0F;</div>
+            <h3>Syntax overview</h3>
+            <p>Modules, bindings, pattern matching, and the = sign.</p>
+          </a>
+        </div>
+
+        <!-- Language Guide -->
+        <h3 style="margin-top: 2.5rem; margin-bottom: 1rem; color: var(--text-primary)">Language guide</h3>
+        <div class="docs-cards">
+          <a class="doc-card" href="https://github.com/Neftedollar/ll-lang/blob/main/docs/language-spec.md" target="_blank" rel="noopener">
+            <div class="doc-card-icon">&#x1F4D6;</div>
+            <h3>Language spec</h3>
+            <p>Formal specification — grammar, type rules, semantics.</p>
+          </a>
+          <a class="doc-card" href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/03-types-and-inference.md" target="_blank" rel="noopener">
+            <div class="doc-card-icon">&#x1F9E0;</div>
+            <h3>Types &amp; inference</h3>
+            <p>Hindley-Milner inference, ADTs, parametric polymorphism.</p>
+          </a>
+          <a class="doc-card" href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/04-tags-and-units.md" target="_blank" rel="noopener">
+            <div class="doc-card-icon">&#x1F3F7;&#xFE0F;</div>
+            <h3>Tags &amp; units</h3>
+            <p>Branded types like <code>Str[Email]</code> and unit checking like <code>Float[m]</code>.</p>
+          </a>
+          <a class="doc-card" href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/05-traits.md" target="_blank" rel="noopener">
+            <div class="doc-card-icon">&#x1F9E9;</div>
+            <h3>Traits</h3>
+            <p>Ad-hoc polymorphism and typeclass-style dispatch.</p>
+          </a>
+          <a class="doc-card" href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/06-modules.md" target="_blank" rel="noopener">
+            <div class="doc-card-icon">&#x1F4E6;</div>
+            <h3>Modules</h3>
+            <p>Module system, imports, and cross-module references.</p>
+          </a>
+        </div>
+
+        <!-- Reference -->
+        <h3 style="margin-top: 2.5rem; margin-bottom: 1rem; color: var(--text-primary)">Reference</h3>
+        <div class="docs-cards">
+          <a class="doc-card" href="https://github.com/Neftedollar/ll-lang/blob/main/docs/stdlib-reference.md" target="_blank" rel="noopener">
+            <div class="doc-card-icon">&#x1F4DA;</div>
+            <h3>Stdlib reference</h3>
+            <p>All 10 stdlib modules — List, Map, Option, Result, and more.</p>
+          </a>
+          <a class="doc-card" href="https://github.com/Neftedollar/ll-lang/blob/main/spec/error-codes.md" target="_blank" rel="noopener">
+            <div class="doc-card-icon">&#x26A0;&#xFE0F;</div>
+            <h3>Error codes</h3>
+            <p>Full E0xx error catalog — code, message, fix hint.</p>
+          </a>
+          <a class="doc-card" href="https://github.com/Neftedollar/ll-lang/blob/main/spec/grammar.ebnf" target="_blank" rel="noopener">
+            <div class="doc-card-icon">&#x1F4DC;</div>
+            <h3>Grammar (EBNF)</h3>
+            <p>Formal grammar for parsing and tooling implementors.</p>
+          </a>
+          <a class="doc-card" href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/08-cli.md" target="_blank" rel="noopener">
+            <div class="doc-card-icon">&#x1F4BB;</div>
+            <h3>CLI reference</h3>
+            <p><code>lllc build</code>, <code>run</code>, <code>check</code>, <code>new</code> — all flags documented.</p>
+          </a>
+        </div>
+
+        <!-- LLM Integration -->
+        <h3 style="margin-top: 2.5rem; margin-bottom: 1rem; color: var(--text-primary)">LLM integration</h3>
+        <div class="docs-cards">
+          <a class="doc-card" href="https://github.com/Neftedollar/ll-lang/blob/main/docs/llm-best-practices.md" target="_blank" rel="noopener">
+            <div class="doc-card-icon">&#x1F916;</div>
+            <h3>LLM best practices</h3>
+            <p>Prompting patterns, error-recovery loops, token budget tips.</p>
+          </a>
+          <a class="doc-card" href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/09-mcp.md" target="_blank" rel="noopener">
+            <div class="doc-card-icon">&#x1F527;</div>
+            <h3>MCP server</h3>
+            <p>Wire ll-lang to Claude Code, Cursor, or Zed via the MCP protocol.</p>
+          </a>
+          <a class="doc-card" href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/09-llm-prompting.md" target="_blank" rel="noopener">
+            <div class="doc-card-icon">&#x1F4AC;</div>
+            <h3>LLM prompting</h3>
+            <p>System prompts, few-shot examples, and structured output modes.</p>
+          </a>
+        </div>
+
+        <!-- Codegen Targets -->
+        <h3 style="margin-top: 2.5rem; margin-bottom: 1rem; color: var(--text-primary)">Codegen targets</h3>
+        <div class="docs-cards">
+          <a class="doc-card" href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/10-targets.md" target="_blank" rel="noopener">
+            <div class="doc-card-icon">&#x1F3AF;</div>
+            <h3>Targets overview</h3>
+            <p>F#, TypeScript, Python, Java 21, C# — differences and flags.</p>
+          </a>
+          <a class="doc-card" href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/11-java-target.md" target="_blank" rel="noopener">
+            <div class="doc-card-icon">&#x2615;</div>
+            <h3>Java target</h3>
+            <p>Sealed interfaces, record patterns, and Java 21 specifics.</p>
+          </a>
+        </div>
+
+      </main>
+    </div>
+  </div>
+
+  <!-- ── Footer ─────────────────────────────────────────────────────────────── -->
+  <footer>
+    <div class="footer-inner">
+      <span class="footer-logo"><span>//</span>ll-lang</span>
+      <ul class="footer-links">
+        <li><a href="https://github.com/Neftedollar/ll-lang" target="_blank" rel="noopener">GitHub</a></li>
+        <li><a href="index.html">Home</a></li>
+        <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a></li>
+      </ul>
+      <p class="footer-copy">&copy; 2025 Neftedollar &mdash; ll-lang v1.0.0</p>
+    </div>
+  </footer>
+
+  <script src="js/main.js"></script>
+</body>
+</html>

--- a/docs-site/docs.html
+++ b/docs-site/docs.html
@@ -1,221 +1,657 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="ll-lang documentation — language spec, stdlib reference, LLM best practices, error codes, and more.">
-  <title>ll-lang — Documentation</title>
-  <link rel="stylesheet" href="css/style.css">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-</head>
-<body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <!-- ── Nav ──────────────────────────────────────────────────────────────── -->
-  <nav>
-    <div class="nav-inner">
-      <a href="index.html" class="nav-logo"><span>//</span>ll-lang</a>
-      <ul class="nav-links" id="nav-links">
-        <li><a href="index.html">Home</a></li>
-        <li><a href="docs.html">Docs</a></li>
-        <li><a href="playground.html">Playground</a></li>
-        <li><a href="https://github.com/Neftedollar/ll-lang" target="_blank" rel="noopener">GitHub</a></li>
-        <li>
-          <a href="https://github.com/Neftedollar/ll-lang/releases" class="nav-cta" target="_blank" rel="noopener">v1.0.0</a>
-        </li>
-      </ul>
-      <button class="nav-hamburger" id="nav-hamburger" aria-label="Toggle navigation" aria-expanded="false">
-        <span></span><span></span><span></span>
-      </button>
-    </div>
-  </nav>
+    <!-- Primary Meta Tags -->
+    <title>ll-lang — Documentation</title>
+    <meta
+      name="description"
+      content="ll-lang documentation — language spec, stdlib reference, LLM best practices, error codes, CLI reference, and codegen targets. The functional language built for LLM code generation."
+    />
+    <meta
+      name="keywords"
+      content="ll-lang docs, functional language documentation, LLM coding language, Hindley-Milner type inference, ADT, MCP server, lllc CLI, F# codegen"
+    />
+    <meta name="author" content="ll-lang contributors" />
+    <link
+      rel="canonical"
+      href="https://neftedollar.github.io/ll-lang/docs.html"
+    />
 
-  <!-- ── Docs layout ───────────────────────────────────────────────────────── -->
-  <div class="container">
-    <div class="docs-layout">
+    <!-- Open Graph / Social -->
+    <meta property="og:type" content="website" />
+    <meta
+      property="og:url"
+      content="https://neftedollar.github.io/ll-lang/docs.html"
+    />
+    <meta property="og:title" content="ll-lang Documentation" />
+    <meta
+      property="og:description"
+      content="Language spec, stdlib reference, error codes, CLI guide, LLM integration docs for ll-lang — the functional language built for LLM code generation."
+    />
+    <meta
+      property="og:image"
+      content="https://neftedollar.github.io/ll-lang/og-image.png"
+    />
 
-      <!-- Sidebar -->
-      <aside class="docs-sidebar">
-        <div class="sidebar-section">
-          <div class="sidebar-section-title">Getting Started</div>
-          <ul class="sidebar-links">
-            <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/docs/getting-started.md" target="_blank" rel="noopener">Getting started</a></li>
-            <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/01-installation.md" target="_blank" rel="noopener">Installation</a></li>
-            <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/02-syntax.md" target="_blank" rel="noopener">Syntax overview</a></li>
-          </ul>
-        </div>
-        <div class="sidebar-section">
-          <div class="sidebar-section-title">Language Guide</div>
-          <ul class="sidebar-links">
-            <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/docs/language-spec.md" target="_blank" rel="noopener">Language spec</a></li>
-            <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/03-types-and-inference.md" target="_blank" rel="noopener">Types &amp; inference</a></li>
-            <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/04-tags-and-units.md" target="_blank" rel="noopener">Tags &amp; units</a></li>
-            <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/05-traits.md" target="_blank" rel="noopener">Traits</a></li>
-            <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/06-modules.md" target="_blank" rel="noopener">Modules</a></li>
-          </ul>
-        </div>
-        <div class="sidebar-section">
-          <div class="sidebar-section-title">Reference</div>
-          <ul class="sidebar-links">
-            <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/docs/stdlib-reference.md" target="_blank" rel="noopener">Stdlib reference</a></li>
-            <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/spec/error-codes.md" target="_blank" rel="noopener">Error codes</a></li>
-            <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/spec/grammar.ebnf" target="_blank" rel="noopener">Grammar (EBNF)</a></li>
-            <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/08-cli.md" target="_blank" rel="noopener">CLI reference</a></li>
-          </ul>
-        </div>
-        <div class="sidebar-section">
-          <div class="sidebar-section-title">LLM Integration</div>
-          <ul class="sidebar-links">
-            <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/docs/llm-best-practices.md" target="_blank" rel="noopener">LLM best practices</a></li>
-            <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/09-mcp.md" target="_blank" rel="noopener">MCP server</a></li>
-            <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/09-llm-prompting.md" target="_blank" rel="noopener">LLM prompting</a></li>
-          </ul>
-        </div>
-        <div class="sidebar-section">
-          <div class="sidebar-section-title">Targets</div>
-          <ul class="sidebar-links">
-            <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/10-targets.md" target="_blank" rel="noopener">Codegen targets</a></li>
-            <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/11-java-target.md" target="_blank" rel="noopener">Java target</a></li>
-          </ul>
-        </div>
-      </aside>
+    <!-- Twitter -->
+    <meta property="twitter:card" content="summary_large_image" />
+    <meta property="twitter:title" content="ll-lang Documentation" />
+    <meta
+      property="twitter:description"
+      content="Language spec, stdlib reference, error codes, CLI guide, and LLM integration docs."
+    />
+    <link rel="stylesheet" href="css/style.css" />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css"
+      integrity="sha384-wH75j6z1lH97ZOpMOInqhgKzFkAInZPPSPlZpYKYTOqsaizPvhQZmAtLcPKXpLyH"
+      crossorigin="anonymous"
+    />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"
+      integrity="sha384-F/bZzf7p3Joyp5psL90p/p89AZJsndkSoGwRpXcZhleCWhd8SnRuoYo4d0yirjJp"
+      crossorigin="anonymous"
+    ></script>
+  </head>
+  <body>
+    <!-- Nav -->
+    <nav>
+      <div class="nav-inner">
+        <a href="index.html" class="nav-logo"><span>//</span>ll-lang</a>
+        <ul class="nav-links" id="nav-links">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="docs.html">Docs</a></li>
+          <li><a href="playground.html">Playground</a></li>
+          <li>
+            <a
+              href="https://github.com/Neftedollar/ll-lang"
+              target="_blank"
+              rel="noopener"
+              >GitHub</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://github.com/Neftedollar/ll-lang/releases"
+              class="nav-cta"
+              target="_blank"
+              rel="noopener"
+              >v1.0.0</a
+            >
+          </li>
+        </ul>
+        <button
+          class="nav-hamburger"
+          id="nav-hamburger"
+          aria-label="Toggle navigation"
+          aria-expanded="false"
+        >
+          <span></span><span></span><span></span>
+        </button>
+      </div>
+    </nav>
 
-      <!-- Main content -->
-      <main class="docs-content">
-        <span class="section-label">Documentation</span>
-        <h2>ll-lang docs</h2>
-        <p>
-          Browse the guides below or jump straight to a topic using the sidebar.
-          All docs live in the repository and open on GitHub.
+    <!-- Page header -->
+    <section style="padding-block: 3rem 1.5rem">
+      <div class="container">
+        <div class="section-label">Documentation</div>
+        <h1
+          style="font-size: clamp(1.8rem, 4vw, 2.6rem); margin-bottom: 0.75rem"
+        >
+          ll-lang reference
+        </h1>
+        <p style="max-width: 56ch; font-size: 1.05rem">
+          Language specification, stdlib reference, error codes, CLI guide, and
+          compiler internals.
         </p>
+      </div>
+    </section>
 
-        <!-- Getting Started -->
-        <h3 style="margin-top: 2.5rem; margin-bottom: 1rem; color: var(--text-primary)">Getting started</h3>
-        <div class="docs-cards">
-          <a class="doc-card" href="https://github.com/Neftedollar/ll-lang/blob/main/docs/getting-started.md" target="_blank" rel="noopener">
-            <div class="doc-card-icon">&#x1F680;</div>
-            <h3>Getting started</h3>
-            <p>Install, write your first program, compile to F# in 5 minutes.</p>
-          </a>
-          <a class="doc-card" href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/01-installation.md" target="_blank" rel="noopener">
-            <div class="doc-card-icon">&#x2699;&#xFE0F;</div>
-            <h3>Installation</h3>
-            <p>Build from source, .NET 10 setup, environment check.</p>
-          </a>
-          <a class="doc-card" href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/02-syntax.md" target="_blank" rel="noopener">
-            <div class="doc-card-icon">&#x270F;&#xFE0F;</div>
-            <h3>Syntax overview</h3>
-            <p>Modules, bindings, pattern matching, and the = sign.</p>
-          </a>
-        </div>
+    <div class="divider"></div>
 
-        <!-- Language Guide -->
-        <h3 style="margin-top: 2.5rem; margin-bottom: 1rem; color: var(--text-primary)">Language guide</h3>
-        <div class="docs-cards">
-          <a class="doc-card" href="https://github.com/Neftedollar/ll-lang/blob/main/docs/language-spec.md" target="_blank" rel="noopener">
-            <div class="doc-card-icon">&#x1F4D6;</div>
-            <h3>Language spec</h3>
-            <p>Formal specification — grammar, type rules, semantics.</p>
-          </a>
-          <a class="doc-card" href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/03-types-and-inference.md" target="_blank" rel="noopener">
-            <div class="doc-card-icon">&#x1F9E0;</div>
-            <h3>Types &amp; inference</h3>
-            <p>Hindley-Milner inference, ADTs, parametric polymorphism.</p>
-          </a>
-          <a class="doc-card" href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/04-tags-and-units.md" target="_blank" rel="noopener">
-            <div class="doc-card-icon">&#x1F3F7;&#xFE0F;</div>
-            <h3>Tags &amp; units</h3>
-            <p>Branded types like <code>Str[Email]</code> and unit checking like <code>Float[m]</code>.</p>
-          </a>
-          <a class="doc-card" href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/05-traits.md" target="_blank" rel="noopener">
-            <div class="doc-card-icon">&#x1F9E9;</div>
-            <h3>Traits</h3>
-            <p>Ad-hoc polymorphism and typeclass-style dispatch.</p>
-          </a>
-          <a class="doc-card" href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/06-modules.md" target="_blank" rel="noopener">
-            <div class="doc-card-icon">&#x1F4E6;</div>
-            <h3>Modules</h3>
-            <p>Module system, imports, and cross-module references.</p>
-          </a>
-        </div>
+    <!-- Docs layout -->
+    <div class="container">
+      <div class="docs-layout">
+        <!-- Sidebar -->
+        <aside class="docs-sidebar">
+          <div class="sidebar-section">
+            <div class="sidebar-section-title">Getting started</div>
+            <ul class="sidebar-links">
+              <li><a href="#quickstart">Quickstart</a></li>
+              <li><a href="#cli">CLI reference</a></li>
+              <li><a href="#project-setup">Project setup</a></li>
+            </ul>
+          </div>
+          <div class="sidebar-section">
+            <div class="sidebar-section-title">Language</div>
+            <ul class="sidebar-links">
+              <li><a href="#syntax">Syntax overview</a></li>
+              <li><a href="#adts">ADTs &amp; pattern matching</a></li>
+              <li><a href="#traits">Traits</a></li>
+              <li><a href="#tags">Tags &amp; unit algebra</a></li>
+              <li><a href="#modules">Modules &amp; imports</a></li>
+              <li><a href="#keywords">Keywords</a></li>
+            </ul>
+          </div>
+          <div class="sidebar-section">
+            <div class="sidebar-section-title">Reference</div>
+            <ul class="sidebar-links">
+              <li><a href="#errors">Error codes (E001&ndash;E026)</a></li>
+              <li><a href="#stdlib">Stdlib module index</a></li>
+            </ul>
+          </div>
+          <div class="sidebar-section">
+            <div class="sidebar-section-title">External</div>
+            <ul class="sidebar-links">
+              <li>
+                <a
+                  href="https://github.com/Neftedollar/ll-lang/blob/main/spec/grammar.ebnf"
+                  target="_blank"
+                  rel="noopener"
+                  >Grammar (EBNF) &rarr;</a
+                >
+              </li>
+              <li>
+                <a
+                  href="https://github.com/Neftedollar/ll-lang/blob/main/spec/type-system.md"
+                  target="_blank"
+                  rel="noopener"
+                  >Type system spec &rarr;</a
+                >
+              </li>
+              <li>
+                <a
+                  href="https://github.com/Neftedollar/ll-lang/blob/main/spec/error-codes.md"
+                  target="_blank"
+                  rel="noopener"
+                  >Full error list &rarr;</a
+                >
+              </li>
+            </ul>
+          </div>
+        </aside>
 
-        <!-- Reference -->
-        <h3 style="margin-top: 2.5rem; margin-bottom: 1rem; color: var(--text-primary)">Reference</h3>
-        <div class="docs-cards">
-          <a class="doc-card" href="https://github.com/Neftedollar/ll-lang/blob/main/docs/stdlib-reference.md" target="_blank" rel="noopener">
-            <div class="doc-card-icon">&#x1F4DA;</div>
-            <h3>Stdlib reference</h3>
-            <p>All 10 stdlib modules — List, Map, Option, Result, and more.</p>
-          </a>
-          <a class="doc-card" href="https://github.com/Neftedollar/ll-lang/blob/main/spec/error-codes.md" target="_blank" rel="noopener">
-            <div class="doc-card-icon">&#x26A0;&#xFE0F;</div>
-            <h3>Error codes</h3>
-            <p>Full E0xx error catalog — code, message, fix hint.</p>
-          </a>
-          <a class="doc-card" href="https://github.com/Neftedollar/ll-lang/blob/main/spec/grammar.ebnf" target="_blank" rel="noopener">
-            <div class="doc-card-icon">&#x1F4DC;</div>
-            <h3>Grammar (EBNF)</h3>
-            <p>Formal grammar for parsing and tooling implementors.</p>
-          </a>
-          <a class="doc-card" href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/08-cli.md" target="_blank" rel="noopener">
-            <div class="doc-card-icon">&#x1F4BB;</div>
-            <h3>CLI reference</h3>
-            <p><code>lllc build</code>, <code>run</code>, <code>check</code>, <code>new</code> — all flags documented.</p>
-          </a>
-        </div>
+        <!-- Content -->
+        <main class="docs-content">
+          <!-- Quickstart -->
+          <section
+            id="quickstart"
+            style="padding-top: 2rem; padding-bottom: 2.5rem"
+          >
+            <h2>Quickstart</h2>
+            <p>
+              Requires
+              <a
+                href="https://dotnet.microsoft.com/download"
+                target="_blank"
+                rel="noopener"
+                >.NET 10</a
+              >.
+            </p>
+            <div class="code-block" style="margin-top: 1rem">
+              <div class="code-block-header">
+                <span class="code-lang">shell</span
+                ><button class="copy-btn">copy</button>
+              </div>
+              <pre><code class="language-bash">git clone https://github.com/Neftedollar/ll-lang.git
+cd ll-lang && dotnet build</code></pre>
+            </div>
+            <div class="code-block" style="margin-top: 1rem">
+              <div class="code-block-header">
+                <span class="code-lang">hello.lll</span
+                ><button class="copy-btn">copy</button>
+              </div>
+              <pre><code class="language-haskell">module Hello
 
-        <!-- LLM Integration -->
-        <h3 style="margin-top: 2.5rem; margin-bottom: 1rem; color: var(--text-primary)">LLM integration</h3>
-        <div class="docs-cards">
-          <a class="doc-card" href="https://github.com/Neftedollar/ll-lang/blob/main/docs/llm-best-practices.md" target="_blank" rel="noopener">
-            <div class="doc-card-icon">&#x1F916;</div>
-            <h3>LLM best practices</h3>
-            <p>Prompting patterns, error-recovery loops, token budget tips.</p>
-          </a>
-          <a class="doc-card" href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/09-mcp.md" target="_blank" rel="noopener">
-            <div class="doc-card-icon">&#x1F527;</div>
-            <h3>MCP server</h3>
-            <p>Wire ll-lang to Claude Code, Cursor, or Zed via the MCP protocol.</p>
-          </a>
-          <a class="doc-card" href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/09-llm-prompting.md" target="_blank" rel="noopener">
-            <div class="doc-card-icon">&#x1F4AC;</div>
-            <h3>LLM prompting</h3>
-            <p>System prompts, few-shot examples, and structured output modes.</p>
-          </a>
-        </div>
+greet(name Str) = printfn "Hello, %s!" name
+Hello = greet "ll-lang"</code></pre>
+            </div>
+            <div class="code-block" style="margin-top: 1rem">
+              <div class="code-block-header">
+                <span class="code-lang">shell</span
+                ><button class="copy-btn">copy</button>
+              </div>
+              <pre><code class="language-bash">lllc run hello.lll
+# Hello, ll-lang!</code></pre>
+            </div>
+          </section>
 
-        <!-- Codegen Targets -->
-        <h3 style="margin-top: 2.5rem; margin-bottom: 1rem; color: var(--text-primary)">Codegen targets</h3>
-        <div class="docs-cards">
-          <a class="doc-card" href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/10-targets.md" target="_blank" rel="noopener">
-            <div class="doc-card-icon">&#x1F3AF;</div>
-            <h3>Targets overview</h3>
-            <p>F#, TypeScript, Python, Java 21, C# — differences and flags.</p>
-          </a>
-          <a class="doc-card" href="https://github.com/Neftedollar/ll-lang/blob/main/docs/user-guide/11-java-target.md" target="_blank" rel="noopener">
-            <div class="doc-card-icon">&#x2615;</div>
-            <h3>Java target</h3>
-            <p>Sealed interfaces, record patterns, and Java 21 specifics.</p>
-          </a>
-        </div>
+          <div class="divider"></div>
 
-      </main>
+          <!-- CLI -->
+          <section id="cli" style="padding-block: 2.5rem">
+            <h2>CLI reference</h2>
+            <div class="code-block" style="margin-top: 1rem">
+              <div class="code-block-header">
+                <span class="code-lang">shell</span>
+              </div>
+              <pre><code class="language-bash">lllc build &lt;file.lll&gt;               # compile to F# (default)
+lllc build --target ts &lt;file.lll&gt;   # compile to TypeScript
+lllc build --target py &lt;file.lll&gt;   # compile to Python
+lllc build --target java &lt;file.lll&gt; # compile to Java 21
+lllc build --target cs &lt;file.lll&gt;   # compile to C#
+lllc build --target llvm &lt;file.lll&gt; # compile to LLVM IR (experimental)
+lllc build [dir]                    # compile project (reads lll.toml)
+lllc check &lt;file.lll&gt;               # type-check only, no codegen
+lllc run   &lt;file.lll&gt;               # compile and run via temp fsproj
+lllc new   &lt;name&gt;                   # scaffold new project
+lllc install                        # resolve deps into vendor/
+lllc mod tidy                       # sync deps
+lllc mod add dep=https://repo#ref   # add a dependency
+lllc mod why dep                    # explain dependency chain
+lllc mcp                            # run MCP server (stdio)</code></pre>
+            </div>
+          </section>
+
+          <div class="divider"></div>
+
+          <!-- Project setup -->
+          <section id="project-setup" style="padding-block: 2.5rem">
+            <h2>Project setup</h2>
+            <p>Multi-file projects use a <code>lll.toml</code> manifest.</p>
+            <div class="code-block" style="margin-top: 1rem">
+              <div class="code-block-header">
+                <span class="code-lang">lll.toml</span
+                ><button class="copy-btn">copy</button>
+              </div>
+              <pre><code class="language-toml">[project]
+name = "myapp"
+
+[platform]
+use = ["fsharp", "typescript"]   # emit both targets on lllc build</code></pre>
+            </div>
+          </section>
+
+          <div class="divider"></div>
+
+          <!-- Syntax -->
+          <section id="syntax" style="padding-block: 2.5rem">
+            <h2>Syntax overview</h2>
+            <p>
+              Uppercase names declare types; lowercase names declare values. No
+              <code>fn</code>, <code>type</code>, <code>in</code>,
+              <code>then</code>, or <code>with</code> keywords. Layout-sensitive
+              (significant indentation).
+            </p>
+            <div class="code-block" style="margin-top: 1rem">
+              <div class="code-block-header">
+                <span class="code-lang">ll-lang</span
+                ><button class="copy-btn">copy</button>
+              </div>
+              <pre><code class="language-haskell">module Examples.Basics
+
+pi = 3.14159
+
+add(a Int)(b Int) Int = a + b
+double(x Int) = x * 2
+
+clamp(x Int)(lo Int)(hi Int) Int =
+  if x < lo
+    lo
+  else if x > hi
+    hi
+  else x
+
+triple = \x. x * 3
+
+example =
+  y = double 5
+  y + 1</code></pre>
+            </div>
+          </section>
+
+          <div class="divider"></div>
+
+          <!-- ADTs -->
+          <section id="adts" style="padding-block: 2.5rem">
+            <h2>ADTs &amp; pattern matching</h2>
+            <div class="code-block">
+              <div class="code-block-header">
+                <span class="code-lang">ll-lang</span
+                ><button class="copy-btn">copy</button>
+              </div>
+              <pre><code class="language-haskell">module Examples.ADTs
+
+Shape = Circle Float | Rect Float Float | Empty
+
+Maybe A = Some A | None
+Result A E = Ok A | Err E
+
+area(s Shape) Float =
+  match s with
+  | Circle r -> 3.14159 * r * r
+  | Rect w h -> w * h
+  | Empty    -> 0.0
+
+safeDivide(a Float)(b Float) Maybe[Float] =
+  if b == 0.0 then None
+  else Some (a / b)</code></pre>
+            </div>
+          </section>
+
+          <div class="divider"></div>
+
+          <!-- Traits -->
+          <section id="traits" style="padding-block: 2.5rem">
+            <h2>Traits</h2>
+            <div class="code-block">
+              <div class="code-block-header">
+                <span class="code-lang">ll-lang</span
+                ><button class="copy-btn">copy</button>
+              </div>
+              <pre><code class="language-haskell">module Examples.Traits
+
+trait Show A =
+  show(a A) Str
+
+impl Show Int =
+  show(n Int) Str = intToStr n
+
+impl Show Bool =
+  show(b Bool) Str = if b then "true" else "false"
+
+printVal(x A) [Show A] = printfn (show x)</code></pre>
+            </div>
+          </section>
+
+          <div class="divider"></div>
+
+          <!-- Tags -->
+          <section id="tags" style="padding-block: 2.5rem">
+            <h2>Tags &amp; unit algebra</h2>
+            <p>
+              Tags are zero-cost type wrappers preventing confusion between
+              values of the same base type.
+            </p>
+            <div class="code-block" style="margin-top: 1rem">
+              <div class="code-block-header">
+                <span class="code-lang">ll-lang</span
+                ><button class="copy-btn">copy</button>
+              </div>
+              <pre><code class="language-haskell">module Examples.Tags
+
+tag UserId
+tag Email
+
+uid = "user-42"[UserId]
+
+getUser(id Str[UserId])  Maybe[Str] = Some "alice"
+sendEmail(to Str[Email])            = to
+
+tag m
+tag s
+
+-- inferred return type: Float[m/s]
+speed(d Float[m])(t Float[s]) = d / t</code></pre>
+            </div>
+          </section>
+
+          <div class="divider"></div>
+
+          <!-- Modules -->
+          <section id="modules" style="padding-block: 2.5rem">
+            <h2>Modules &amp; imports</h2>
+            <div class="code-block">
+              <div class="code-block-header">
+                <span class="code-lang">ll-lang</span
+                ><button class="copy-btn">copy</button>
+              </div>
+              <pre><code class="language-haskell">module Examples.App
+
+import Map
+import Toml
+
+config = Toml.parse (readFile "config.toml")</code></pre>
+            </div>
+          </section>
+
+          <div class="divider"></div>
+
+          <!-- Keywords -->
+          <section id="keywords" style="padding-block: 2.5rem">
+            <h2>Keywords</h2>
+            <p>
+              ll-lang has exactly <strong>15 keywords</strong>. Everything else
+              is expressed through the uppercase/lowercase convention.
+            </p>
+            <p
+              style="
+                font-family: var(--font-mono);
+                font-size: 0.9rem;
+                margin-top: 0.75rem;
+                color: var(--text-primary);
+              "
+            >
+              <code>match</code> &nbsp; <code>if</code> &nbsp;
+              <code>else</code> &nbsp; <code>import</code> &nbsp;
+              <code>export</code> &nbsp; <code>module</code> &nbsp;
+              <code>trait</code> &nbsp; <code>impl</code> &nbsp;
+              <code>external</code> &nbsp; <code>opaque</code> &nbsp;
+              <code>tag</code> &nbsp; <code>unit</code> &nbsp;
+              <code>true</code> &nbsp; <code>false</code> &nbsp;
+              <code>let</code>
+            </p>
+          </section>
+
+          <div class="divider"></div>
+
+          <!-- Error codes -->
+          <section id="errors" style="padding-block: 2.5rem">
+            <h2>Error codes</h2>
+            <p>
+              Format: <code>EXXX line:col ErrorKind details</code>. One line per
+              error, no stack traces.
+            </p>
+            <div
+              class="code-block"
+              style="margin-top: 1.25rem; overflow-x: auto"
+            >
+              <table class="error-table">
+                <thead>
+                  <tr>
+                    <th>Code</th>
+                    <th>Kind</th>
+                    <th>Example output</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td class="error-code">E001</td>
+                    <td>TypeMismatch</td>
+                    <td class="error-example">
+                      E001 12:5 TypeMismatch Str Str[UserId]
+                    </td>
+                  </tr>
+                  <tr>
+                    <td class="error-code">E002</td>
+                    <td>UnboundVar</td>
+                    <td class="error-example">E002 8:3 UnboundVar username</td>
+                  </tr>
+                  <tr>
+                    <td class="error-code">E003</td>
+                    <td>NonExhaustiveMatch</td>
+                    <td class="error-example">
+                      E003 15:1 NonExhaustiveMatch Shape missing:Empty
+                    </td>
+                  </tr>
+                  <tr>
+                    <td class="error-code">E004</td>
+                    <td>UnitMismatch</td>
+                    <td class="error-example">
+                      E004 20:9 UnitMismatch Float[m] Float[s]
+                    </td>
+                  </tr>
+                  <tr>
+                    <td class="error-code">E005</td>
+                    <td>TagViolation</td>
+                    <td class="error-example">
+                      E005 7:14 TagViolation Str[Email] Str[UserId]
+                    </td>
+                  </tr>
+                  <tr>
+                    <td class="error-code">E006</td>
+                    <td>TraitNotImpl</td>
+                    <td class="error-example">
+                      E006 &mdash; no impl of Show for MyType
+                    </td>
+                  </tr>
+                  <tr>
+                    <td class="error-code">E008</td>
+                    <td>OccursCheck</td>
+                    <td class="error-example">
+                      E008 &mdash; infinite type detected
+                    </td>
+                  </tr>
+                  <tr>
+                    <td class="error-code">E020</td>
+                    <td>ModuleCycle</td>
+                    <td class="error-example">
+                      E020 &mdash; cyclic import A &rarr; B &rarr; A
+                    </td>
+                  </tr>
+                  <tr>
+                    <td class="error-code">E024</td>
+                    <td>UnresolvedDep</td>
+                    <td class="error-example">
+                      E024 &mdash; dependency not found in vendor/
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <p style="margin-top: 1rem; font-size: 0.88rem">
+              Full list E001&ndash;E026:
+              <a
+                href="https://github.com/Neftedollar/ll-lang/blob/main/spec/error-codes.md"
+                target="_blank"
+                rel="noopener"
+                >spec/error-codes.md &rarr;</a
+              >
+            </p>
+          </section>
+
+          <div class="divider"></div>
+
+          <!-- Stdlib -->
+          <section id="stdlib" style="padding-block: 2.5rem">
+            <h2>Stdlib module index</h2>
+            <p>10 self-hosted modules (5,857 LOC of ll-lang).</p>
+            <div
+              class="code-block"
+              style="margin-top: 1.25rem; overflow-x: auto"
+            >
+              <table class="error-table">
+                <thead>
+                  <tr>
+                    <th>Module</th>
+                    <th>LOC</th>
+                    <th>Description</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td class="error-code">Map.lll</td>
+                    <td>223</td>
+                    <td>Okasaki red-black tree, O(log n)</td>
+                  </tr>
+                  <tr>
+                    <td class="error-code">Toml.lll</td>
+                    <td>292</td>
+                    <td>TOML config parser</td>
+                  </tr>
+                  <tr>
+                    <td class="error-code">Lexer.lll</td>
+                    <td>473</td>
+                    <td>Tokenizer with layout (INDENT/DEDENT)</td>
+                  </tr>
+                  <tr>
+                    <td class="error-code">Parser.lll</td>
+                    <td>802</td>
+                    <td>Recursive descent parser</td>
+                  </tr>
+                  <tr>
+                    <td class="error-code">Elaborator.lll</td>
+                    <td>344</td>
+                    <td>Type checker / name resolver</td>
+                  </tr>
+                  <tr>
+                    <td class="error-code">Codegen.lll</td>
+                    <td>569</td>
+                    <td>F# source emitter</td>
+                  </tr>
+                  <tr>
+                    <td class="error-code">CodegenTS.lll</td>
+                    <td>492</td>
+                    <td>TypeScript source emitter</td>
+                  </tr>
+                  <tr>
+                    <td class="error-code">CodegenPy.lll</td>
+                    <td>501</td>
+                    <td>Python source emitter</td>
+                  </tr>
+                  <tr>
+                    <td class="error-code">CodegenJava.lll</td>
+                    <td>633</td>
+                    <td>Java 21 source emitter</td>
+                  </tr>
+                  <tr>
+                    <td class="error-code">Compiler.lll</td>
+                    <td>1516</td>
+                    <td>Full pipeline (source &rarr; F#)</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <p style="margin-top: 1rem; font-size: 0.88rem">
+              Browse source:
+              <a
+                href="https://github.com/Neftedollar/ll-lang/tree/main/stdlib"
+                target="_blank"
+                rel="noopener"
+                >github.com/Neftedollar/ll-lang/tree/main/stdlib &rarr;</a
+              >
+            </p>
+          </section>
+        </main>
+      </div>
     </div>
-  </div>
 
-  <!-- ── Footer ─────────────────────────────────────────────────────────────── -->
-  <footer>
-    <div class="footer-inner">
-      <span class="footer-logo"><span>//</span>ll-lang</span>
-      <ul class="footer-links">
-        <li><a href="https://github.com/Neftedollar/ll-lang" target="_blank" rel="noopener">GitHub</a></li>
-        <li><a href="index.html">Home</a></li>
-        <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a></li>
-      </ul>
-      <p class="footer-copy">&copy; 2025 Neftedollar &mdash; ll-lang v1.0.0</p>
-    </div>
-  </footer>
+    <!-- Footer -->
+    <footer>
+      <div class="footer-inner">
+        <span class="footer-logo"><span>//</span>ll-lang</span>
+        <ul class="footer-links">
+          <li>
+            <a
+              href="https://github.com/Neftedollar/ll-lang"
+              target="_blank"
+              rel="noopener"
+              >GitHub</a
+            >
+          </li>
+          <li><a href="index.html">Home</a></li>
+          <li><a href="playground.html">Playground</a></li>
+          <li>
+            <a
+              href="https://github.com/Neftedollar/ll-lang/blob/main/LICENSE"
+              target="_blank"
+              rel="noopener"
+              >MIT License</a
+            >
+          </li>
+        </ul>
+        <p class="footer-copy">
+          &copy; 2025 Neftedollar &mdash; ll-lang v1.0.0
+        </p>
+      </div>
+    </footer>
 
-  <script src="js/main.js"></script>
-</body>
+    <script>
+      hljs.highlightAll();
+    </script>
+    <script src="js/main.js"></script>
+  </body>
 </html>

--- a/docs-site/index.html
+++ b/docs-site/index.html
@@ -1,140 +1,205 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>ll-lang &mdash; The language built for LLMs to write, compile, and fix</title>
-  <meta name="description" content="Token-efficient functional syntax. Machine-readable errors. Compiles to F#, TypeScript, Python, Java, C#." />
-  <meta property="og:title" content="ll-lang" />
-  <meta property="og:description" content="The language built for LLMs to write, compile, and fix." />
-  <meta property="og:type" content="website" />
-  <link rel="stylesheet" href="css/style.css" />
-  <link
-    rel="stylesheet"
-    href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css"
-    integrity="sha384-wH75j6z1lH97ZOpMOInqhgKzFkAInZPPSPlZpYKYTOqsaizPvhQZmAtLcPKXpLyH"
-    crossorigin="anonymous"
-  />
-  <script
-    src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"
-    integrity="sha384-F/bZzf7p3Joyp5psL90p/p89AZJsndkSoGwRpXcZhleCWhd8SnRuoYo4d0yirjJp"
-    crossorigin="anonymous"
-  ></script>
-</head>
-<body>
-
-<!-- Nav -->
-<nav>
-  <div class="nav-inner">
-    <a href="index.html" class="nav-logo"><span>//</span>ll-lang</a>
-    <ul class="nav-links" id="nav-links">
-      <li><a href="index.html">Home</a></li>
-      <li><a href="docs.html">Docs</a></li>
-      <li><a href="playground.html">Playground</a></li>
-      <li><a href="https://github.com/Neftedollar/ll-lang" target="_blank" rel="noopener">GitHub</a></li>
-      <li><a href="https://github.com/Neftedollar/ll-lang/releases" class="nav-cta" target="_blank" rel="noopener">v1.0.0</a></li>
-    </ul>
-    <button class="nav-hamburger" id="nav-hamburger" aria-label="Toggle navigation" aria-expanded="false">
-      <span></span><span></span><span></span>
-    </button>
-  </div>
-</nav>
-
-<!-- Hero -->
-<section class="hero">
-  <div class="container">
-    <div class="hero-badge">
-      <span class="dot"></span>v1.0.0 &mdash; Bootstrap fixpoint achieved
-    </div>
-    <h1>The language built for LLMs to write, compile, and fix</h1>
-    <p class="hero-sub">
-      Token-efficient functional syntax. Machine-readable errors.
-      Compiles to F#, TypeScript, Python, Java, C#.
-    </p>
-    <div class="hero-actions">
-      <a href="playground.html" class="btn btn-primary">&#x25B6; Try with lllc</a>
-      <a href="https://github.com/Neftedollar/ll-lang" class="btn btn-secondary" target="_blank" rel="noopener">&#x2605; View on GitHub</a>
-      <a href="docs.html" class="btn btn-ghost">Read the docs &rarr;</a>
-    </div>
-
-    <!-- Terminal mockup -->
-    <div class="hero-terminal">
-      <div class="terminal-bar">
-        <span class="dot red"></span>
-        <span class="dot yellow"></span>
-        <span class="dot green"></span>
-        <span class="terminal-title">hello.lll</span>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>
+      ll-lang &mdash; The language built for LLMs to write, compile, and fix
+    </title>
+    <meta
+      name="description"
+      content="Token-efficient functional syntax. Machine-readable errors. Compiles to F#, TypeScript, Python, Java, C#."
+    />
+    <meta
+      name="keywords"
+      content="ll-lang, functional programming language, LLM code generation, AI coding language, token efficient, static typing, F# codegen"
+    />
+    <meta name="author" content="ll-lang contributors" />
+    <link rel="canonical" href="https://neftedollar.github.io/ll-lang/" />
+    <meta property="og:title" content="ll-lang — The Language Built for LLMs" />
+    <meta
+      property="og:description"
+      content="Token-efficient functional syntax. Machine-readable errors. Multi-target codegen."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://neftedollar.github.io/ll-lang/" />
+    <meta
+      property="og:image"
+      content="https://neftedollar.github.io/ll-lang/og-image.png"
+    />
+    <meta property="twitter:card" content="summary_large_image" />
+    <meta
+      property="twitter:title"
+      content="ll-lang — The Language Built for LLMs"
+    />
+    <meta
+      property="twitter:description"
+      content="Token-efficient functional syntax. Machine-readable errors. Multi-target codegen."
+    />
+    <link rel="stylesheet" href="css/style.css" />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css"
+      integrity="sha384-wH75j6z1lH97ZOpMOInqhgKzFkAInZPPSPlZpYKYTOqsaizPvhQZmAtLcPKXpLyH"
+      crossorigin="anonymous"
+    />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"
+      integrity="sha384-F/bZzf7p3Joyp5psL90p/p89AZJsndkSoGwRpXcZhleCWhd8SnRuoYo4d0yirjJp"
+      crossorigin="anonymous"
+    ></script>
+  </head>
+  <body>
+    <!-- Nav -->
+    <nav>
+      <div class="nav-inner">
+        <a href="index.html" class="nav-logo"><span>//</span>ll-lang</a>
+        <ul class="nav-links" id="nav-links">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="docs.html">Docs</a></li>
+          <li><a href="playground.html">Playground</a></li>
+          <li>
+            <a
+              href="https://github.com/Neftedollar/ll-lang"
+              target="_blank"
+              rel="noopener"
+              >GitHub</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://github.com/Neftedollar/ll-lang/releases"
+              class="nav-cta"
+              target="_blank"
+              rel="noopener"
+              >v1.0.0</a
+            >
+          </li>
+        </ul>
+        <button
+          class="nav-hamburger"
+          id="nav-hamburger"
+          aria-label="Toggle navigation"
+          aria-expanded="false"
+        >
+          <span></span><span></span><span></span>
+        </button>
       </div>
-      <div class="terminal-body">
-        <div><span class="t-keyword">module</span> Hello</div>
-        <div>&nbsp;</div>
-        <div><span class="t-comment">-- no fn keyword, no braces, no ceremony</span></div>
-        <div>greet(name <span class="t-type">Str</span>) = <span class="t-keyword">printfn</span> <span class="t-string">"Hello, %s!"</span> name</div>
-        <div>&nbsp;</div>
-        <div>Hello = greet <span class="t-string">"ll-lang"</span></div>
-        <div>&nbsp;</div>
-        <div><span class="t-prompt">$</span> lllc run hello.lll</div>
-        <div><span class="t-success">Hello, ll-lang!</span></div>
-      </div>
-    </div>
-  </div>
-</section>
+    </nav>
 
-<!-- Stats -->
-<section style="padding-block: 0 4rem">
-  <div class="container">
-    <div class="stats-bar">
-      <div class="stat-item">
-        <div class="stat-value">5,857</div>
-        <div class="stat-label">LOC self-hosted stdlib</div>
-      </div>
-      <div class="stat-item">
-        <div class="stat-value">10</div>
-        <div class="stat-label">stdlib modules</div>
-      </div>
-      <div class="stat-item">
-        <div class="stat-value">5</div>
-        <div class="stat-label">compile targets</div>
-      </div>
-      <div class="stat-item">
-        <div class="stat-value">15</div>
-        <div class="stat-label">keywords total</div>
-      </div>
-      <div class="stat-item">
-        <div class="stat-value">8&ndash;17%</div>
-        <div class="stat-label">fewer tokens vs F#</div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<div class="divider"></div>
-
-<!-- Features -->
-<section id="features">
-  <div class="container">
-    <div class="section-label">Features</div>
-    <h2 class="section-title">Built differently, on purpose</h2>
-    <p class="section-sub">
-      Every design decision is evaluated against one goal: LLM agents
-      writing correct code on the first attempt.
-    </p>
-
-    <div class="features-grid">
-
-      <!-- Feature 1: Zero ceremony -->
-      <div class="feature-card">
-        <div class="feature-icon">&#x26A1;</div>
-        <h3>Zero ceremony</h3>
-        <p>
-          No <code>fn</code>, <code>type</code>, <code>in</code>, <code>then</code>,
-          or <code>with</code> keywords. Uppercase declares types; lowercase declares
-          values. The body follows <code>=</code>.
+    <!-- Hero -->
+    <section class="hero">
+      <div class="container">
+        <div class="hero-badge">
+          <span class="dot"></span>v1.0.0 &mdash; Bootstrap fixpoint achieved
+        </div>
+        <h1>The language built for LLMs to write, compile, and fix</h1>
+        <p class="hero-sub">
+          Token-efficient functional syntax. Machine-readable errors. Compiles
+          to F#, TypeScript, Python, Java, C#.
         </p>
-        <div class="code-compare">
-          <div class="code-block">
-            <div class="compare-label"><span class="badge badge-before">verbose</span>TypeScript</div>
-            <pre><code class="language-typescript">type Shape =
+        <div class="hero-actions">
+          <a href="playground.html" class="btn btn-primary"
+            >&#x25B6; Try with lllc</a
+          >
+          <a
+            href="https://github.com/Neftedollar/ll-lang"
+            class="btn btn-secondary"
+            target="_blank"
+            rel="noopener"
+            >&#x2605; View on GitHub</a
+          >
+          <a href="docs.html" class="btn btn-ghost">Read the docs &rarr;</a>
+        </div>
+
+        <!-- Terminal mockup -->
+        <div class="hero-terminal">
+          <div class="terminal-bar">
+            <span class="dot red"></span>
+            <span class="dot yellow"></span>
+            <span class="dot green"></span>
+            <span class="terminal-title">hello.lll</span>
+          </div>
+          <div class="terminal-body">
+            <div><span class="t-keyword">module</span> Hello</div>
+            <div>&nbsp;</div>
+            <div>
+              <span class="t-comment"
+                >-- no fn keyword, no braces, no ceremony</span
+              >
+            </div>
+            <div>
+              greet(name <span class="t-type">Str</span>) =
+              <span class="t-keyword">printfn</span>
+              <span class="t-string">"Hello, %s!"</span> name
+            </div>
+            <div>&nbsp;</div>
+            <div>Hello = greet <span class="t-string">"ll-lang"</span></div>
+            <div>&nbsp;</div>
+            <div><span class="t-prompt">$</span> lllc run hello.lll</div>
+            <div><span class="t-success">Hello, ll-lang!</span></div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Stats -->
+    <section style="padding-block: 0 4rem">
+      <div class="container">
+        <div class="stats-bar">
+          <div class="stat-item">
+            <div class="stat-value">5,857</div>
+            <div class="stat-label">LOC self-hosted stdlib</div>
+          </div>
+          <div class="stat-item">
+            <div class="stat-value">10</div>
+            <div class="stat-label">stdlib modules</div>
+          </div>
+          <div class="stat-item">
+            <div class="stat-value">5</div>
+            <div class="stat-label">compile targets</div>
+          </div>
+          <div class="stat-item">
+            <div class="stat-value">15</div>
+            <div class="stat-label">keywords total</div>
+          </div>
+          <div class="stat-item">
+            <div class="stat-value">8&ndash;17%</div>
+            <div class="stat-label">fewer tokens vs F#</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <div class="divider"></div>
+
+    <!-- Features -->
+    <section id="features">
+      <div class="container">
+        <div class="section-label">Features</div>
+        <h2 class="section-title">Built differently, on purpose</h2>
+        <p class="section-sub">
+          Every design decision is evaluated against one goal: LLM agents
+          writing correct code on the first attempt.
+        </p>
+
+        <div class="features-grid">
+          <!-- Feature 1: Zero ceremony -->
+          <div class="feature-card">
+            <div class="feature-icon">&#x26A1;</div>
+            <h3>Zero ceremony</h3>
+            <p>
+              No <code>fn</code>, <code>type</code>, <code>in</code>,
+              <code>then</code>, or <code>with</code> keywords. Uppercase
+              declares types; lowercase declares values. The body follows
+              <code>=</code>.
+            </p>
+            <div class="code-compare">
+              <div class="code-block">
+                <div class="compare-label">
+                  <span class="badge badge-before">verbose</span>TypeScript
+                </div>
+                <pre><code class="language-typescript">type Shape =
   | { kind: "Circle"; r: number }
   | { kind: "Rect"; w: number; h: number }
 
@@ -144,180 +209,213 @@ function area(s: Shape): number {
     case "Rect":   return s.w * s.h;
   }
 }</code></pre>
-          </div>
-          <div class="code-block">
-            <div class="compare-label"><span class="badge badge-after">compact</span>ll-lang</div>
-            <pre><code class="language-haskell">Shape = Circle Float | Rect Float Float
+              </div>
+              <div class="code-block">
+                <div class="compare-label">
+                  <span class="badge badge-after">compact</span>ll-lang
+                </div>
+                <pre><code class="language-haskell">Shape = Circle Float | Rect Float Float
 
 area(s Shape) Float =
   match s with
   | Circle r   -> 3.14159 * r * r
   | Rect w h   -> w * h</code></pre>
+              </div>
+            </div>
           </div>
-        </div>
-      </div>
 
-      <!-- Feature 2: LLM errors -->
-      <div class="feature-card">
-        <div class="feature-icon">&#x1F916;</div>
-        <h3>Errors LLMs understand</h3>
-        <p>
-          All errors are short, structured, and machine-readable. One line
-          per error, parseable by regex &mdash; no stack traces, no prose.
-        </p>
-        <div class="code-block">
-          <div class="code-block-header">
-            <span class="code-lang">compiler output</span>
-          </div>
-          <pre><code class="language-plaintext">E001 12:5  TypeMismatch     expected Str[UserId] got Str
+          <!-- Feature 2: LLM errors -->
+          <div class="feature-card">
+            <div class="feature-icon">&#x1F916;</div>
+            <h3>Errors LLMs understand</h3>
+            <p>
+              All errors are short, structured, and machine-readable. One line
+              per error, parseable by regex &mdash; no stack traces, no prose.
+            </p>
+            <div class="code-block">
+              <div class="code-block-header">
+                <span class="code-lang">compiler output</span>
+              </div>
+              <pre><code class="language-plaintext">E001 12:5  TypeMismatch     expected Str[UserId] got Str
 E003 15:1  NonExhaustiveMatch Shape missing:Empty
 E004 20:9  UnitMismatch     Float[m] vs Float[s]
 E005  7:14 TagViolation     Str[Email] != Str[UserId]
 E002  8:3  UnboundVar       username</code></pre>
-        </div>
-        <p style="margin-top:.75rem;margin-bottom:0;font-size:.85rem">
-          Format: <code>EXXX line:col ErrorKind details</code> &mdash; the agent
-          reads the error, patches the source, recompiles. No scraping.
-        </p>
-      </div>
-
-      <!-- Feature 3: Multi-target -->
-      <div class="feature-card">
-        <div class="feature-icon">&#x1F3AF;</div>
-        <h3>Multi-target codegen</h3>
-        <p>
-          Write once in ll-lang. Compile to F#, TypeScript, Python, Java 21,
-          or C# from the same source &mdash; same semantics, idiomatic output
-          per target.
-        </p>
-        <div class="code-block">
-          <div class="code-block-header">
-            <span class="code-lang">shell</span>
-            <button class="copy-btn">copy</button>
+            </div>
+            <p
+              style="margin-top: 0.75rem; margin-bottom: 0; font-size: 0.85rem"
+            >
+              Format: <code>EXXX line:col ErrorKind details</code> &mdash; the
+              agent reads the error, patches the source, recompiles. No
+              scraping.
+            </p>
           </div>
-          <pre><code class="language-bash">lllc build --target fs   adts.lll  # F# discriminated unions
+
+          <!-- Feature 3: Multi-target -->
+          <div class="feature-card">
+            <div class="feature-icon">&#x1F3AF;</div>
+            <h3>Multi-target codegen</h3>
+            <p>
+              Write once in ll-lang. Compile to F#, TypeScript, Python, Java 21,
+              or C# from the same source &mdash; same semantics, idiomatic
+              output per target.
+            </p>
+            <div class="code-block">
+              <div class="code-block-header">
+                <span class="code-lang">shell</span>
+                <button class="copy-btn">copy</button>
+              </div>
+              <pre><code class="language-bash">lllc build --target fs   adts.lll  # F# discriminated unions
 lllc build --target ts   adts.lll  # TypeScript sealed interfaces
 lllc build --target py   adts.lll  # Python @dataclass + Union
 lllc build --target java adts.lll  # Java 21 sealed interfaces
 lllc build --target cs   adts.lll  # C# records + interfaces</code></pre>
-        </div>
-        <div class="targets-grid" style="margin-top:1rem">
-          <div class="target-card"><div class="t-icon">&#x1F4B3;</div><div class="t-name">F#</div><div class="t-flag">--target fs</div><span class="t-stable stable">stable</span></div>
-          <div class="target-card"><div class="t-icon">&#x1F4D8;</div><div class="t-name">TypeScript</div><div class="t-flag">--target ts</div><span class="t-stable stable">stable</span></div>
-          <div class="target-card"><div class="t-icon">&#x1F40D;</div><div class="t-name">Python</div><div class="t-flag">--target py</div><span class="t-stable stable">stable</span></div>
-          <div class="target-card"><div class="t-icon">&#x2615;</div><div class="t-name">Java 21</div><div class="t-flag">--target java</div><span class="t-stable stable">stable</span></div>
-          <div class="target-card"><div class="t-icon">&#x1F4E6;</div><div class="t-name">C#</div><div class="t-flag">--target cs</div><span class="t-stable stable">stable</span></div>
-        </div>
-      </div>
-
-    </div>
-  </div>
-</section>
-
-<div class="divider"></div>
-
-<!-- Quickstart -->
-<section id="quickstart">
-  <div class="container">
-    <div class="section-label">Quickstart</div>
-    <h2 class="section-title">Up in 60 seconds</h2>
-    <p class="section-sub">
-      Requires <a href="https://dotnet.microsoft.com/download" target="_blank" rel="noopener">.NET 10</a>.
-    </p>
-
-    <div class="quickstart-steps">
-
-      <div class="qs-step">
-        <div class="qs-num">1</div>
-        <div class="qs-content">
-          <h3>Get the compiler</h3>
-          <div class="code-block">
-            <div class="code-block-header">
-              <span class="code-lang">shell</span>
-              <button class="copy-btn">copy</button>
             </div>
-            <pre><code class="language-bash">git clone https://github.com/Neftedollar/ll-lang.git
-cd ll-lang
-dotnet build
-dotnet test   # optional: run full test suite</code></pre>
+            <div class="targets-grid" style="margin-top: 1rem">
+              <div class="target-card">
+                <div class="t-icon">&#x1F4B3;</div>
+                <div class="t-name">F#</div>
+                <div class="t-flag">--target fs</div>
+                <span class="t-stable stable">stable</span>
+              </div>
+              <div class="target-card">
+                <div class="t-icon">&#x1F4D8;</div>
+                <div class="t-name">TypeScript</div>
+                <div class="t-flag">--target ts</div>
+                <span class="t-stable stable">stable</span>
+              </div>
+              <div class="target-card">
+                <div class="t-icon">&#x1F40D;</div>
+                <div class="t-name">Python</div>
+                <div class="t-flag">--target py</div>
+                <span class="t-stable stable">stable</span>
+              </div>
+              <div class="target-card">
+                <div class="t-icon">&#x2615;</div>
+                <div class="t-name">Java 21</div>
+                <div class="t-flag">--target java</div>
+                <span class="t-stable stable">stable</span>
+              </div>
+              <div class="target-card">
+                <div class="t-icon">&#x1F4E6;</div>
+                <div class="t-name">C#</div>
+                <div class="t-flag">--target cs</div>
+                <span class="t-stable stable">stable</span>
+              </div>
+            </div>
           </div>
         </div>
       </div>
+    </section>
 
-      <div class="qs-step">
-        <div class="qs-num">2</div>
-        <div class="qs-content">
-          <h3>Write your first program</h3>
-          <div class="code-block">
-            <div class="code-block-header">
-              <span class="code-lang">hello.lll</span>
-              <button class="copy-btn">copy</button>
+    <div class="divider"></div>
+
+    <!-- Quickstart -->
+    <section id="quickstart">
+      <div class="container">
+        <div class="section-label">Quickstart</div>
+        <h2 class="section-title">Up in 60 seconds</h2>
+        <p class="section-sub">
+          Requires
+          <a
+            href="https://dotnet.microsoft.com/download"
+            target="_blank"
+            rel="noopener"
+            >.NET 10</a
+          >.
+        </p>
+
+        <div class="quickstart-steps">
+          <div class="qs-step">
+            <div class="qs-num">1</div>
+            <div class="qs-content">
+              <h3>Get the compiler</h3>
+              <div class="code-block">
+                <div class="code-block-header">
+                  <span class="code-lang">shell</span>
+                  <button class="copy-btn">copy</button>
+                </div>
+                <pre><code class="language-bash">git clone https://github.com/Neftedollar/ll-lang.git
+cd ll-lang
+dotnet build
+dotnet test   # optional: run full test suite</code></pre>
+              </div>
             </div>
-            <pre><code class="language-haskell">module Hello
+          </div>
+
+          <div class="qs-step">
+            <div class="qs-num">2</div>
+            <div class="qs-content">
+              <h3>Write your first program</h3>
+              <div class="code-block">
+                <div class="code-block-header">
+                  <span class="code-lang">hello.lll</span>
+                  <button class="copy-btn">copy</button>
+                </div>
+                <pre><code class="language-haskell">module Hello
 
 -- greet takes a Str, returns nothing (unit)
 greet(name Str) = printfn "Hello, %s!" name
 
 -- entry point: uppercase name, no args
 Hello = greet "ll-lang"</code></pre>
-          </div>
-        </div>
-      </div>
-
-      <div class="qs-step">
-        <div class="qs-num">3</div>
-        <div class="qs-content">
-          <h3>Compile and run</h3>
-          <div class="code-block">
-            <div class="code-block-header">
-              <span class="code-lang">shell</span>
-              <button class="copy-btn">copy</button>
+              </div>
             </div>
-            <pre><code class="language-bash">lllc run hello.lll
+          </div>
+
+          <div class="qs-step">
+            <div class="qs-num">3</div>
+            <div class="qs-content">
+              <h3>Compile and run</h3>
+              <div class="code-block">
+                <div class="code-block-header">
+                  <span class="code-lang">shell</span>
+                  <button class="copy-btn">copy</button>
+                </div>
+                <pre><code class="language-bash">lllc run hello.lll
 # Hello, ll-lang!</code></pre>
-          </div>
-        </div>
-      </div>
-
-      <div class="qs-step">
-        <div class="qs-num">4</div>
-        <div class="qs-content">
-          <h3>Scaffold a multi-file project</h3>
-          <div class="code-block">
-            <div class="code-block-header">
-              <span class="code-lang">shell</span>
-              <button class="copy-btn">copy</button>
+              </div>
             </div>
-            <pre><code class="language-bash">lllc new myapp          # creates myapp/lll.toml + src/Main.lll
+          </div>
+
+          <div class="qs-step">
+            <div class="qs-num">4</div>
+            <div class="qs-content">
+              <h3>Scaffold a multi-file project</h3>
+              <div class="code-block">
+                <div class="code-block-header">
+                  <span class="code-lang">shell</span>
+                  <button class="copy-btn">copy</button>
+                </div>
+                <pre><code class="language-bash">lllc new myapp          # creates myapp/lll.toml + src/Main.lll
 cd myapp
 lllc build              # emits bin/fsharp/myapp.fsproj
 dotnet run --project bin/fsharp/myapp.fsproj</code></pre>
+              </div>
+            </div>
           </div>
         </div>
       </div>
+    </section>
 
-    </div>
-  </div>
-</section>
+    <div class="divider"></div>
 
-<div class="divider"></div>
-
-<!-- MCP -->
-<section id="mcp">
-  <div class="container">
-    <div class="section-label">MCP Integration</div>
-    <h2 class="section-title">Wire it to your LLM client</h2>
-    <p class="section-sub">
-      ll-lang ships a built-in MCP server. Connect it to Claude Code, Cursor,
-      or Zed &mdash; your agent gets structured tools to compile, check, and
-      run ll-lang without parsing shell output.
-    </p>
-    <div class="code-block">
-      <div class="code-block-header">
-        <span class="code-lang">claude_desktop_config.json</span>
-        <button class="copy-btn">copy</button>
-      </div>
-      <pre><code class="language-json">{
+    <!-- MCP -->
+    <section id="mcp">
+      <div class="container">
+        <div class="section-label">MCP Integration</div>
+        <h2 class="section-title">Wire it to your LLM client</h2>
+        <p class="section-sub">
+          ll-lang ships a built-in MCP server. Connect it to Claude Code,
+          Cursor, or Zed &mdash; your agent gets structured tools to compile,
+          check, and run ll-lang without parsing shell output.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">
+            <span class="code-lang">claude_desktop_config.json</span>
+            <button class="copy-btn">copy</button>
+          </div>
+          <pre><code class="language-json">{
   "mcpServers": {
     "lllc": {
       "command": "dotnet",
@@ -325,60 +423,106 @@ dotnet run --project bin/fsharp/myapp.fsproj</code></pre>
     }
   }
 }</code></pre>
-    </div>
-    <p style="margin-top:1rem;font-size:.9rem">
-      10 MCP tools:
-      <code>compile_file</code>, <code>compile_source</code>, <code>check_file</code>,
-      <code>check_source</code>, <code>run_file</code>, <code>list_errors</code>,
-      <code>lookup_error</code>, <code>stdlib_search</code>, <code>grammar_lookup</code>,
-      <code>project_info</code>.
-    </p>
-  </div>
-</section>
+        </div>
+        <p style="margin-top: 1rem; font-size: 0.9rem">
+          10 MCP tools:
+          <code>compile_file</code>, <code>compile_source</code>,
+          <code>check_file</code>, <code>check_source</code>,
+          <code>run_file</code>, <code>list_errors</code>,
+          <code>lookup_error</code>, <code>stdlib_search</code>,
+          <code>grammar_lookup</code>, <code>project_info</code>.
+        </p>
+      </div>
+    </section>
 
-<div class="divider"></div>
+    <div class="divider"></div>
 
-<!-- Community -->
-<section id="community">
-  <div class="container">
-    <div class="section-label">Community</div>
-    <h2 class="section-title">Get involved</h2>
-    <div class="links-grid">
-      <a href="https://github.com/Neftedollar/ll-lang" class="link-card" target="_blank" rel="noopener">
-        <span class="l-icon">&#x2605;</span>
-        <div><div class="l-title">GitHub</div><div class="l-desc">Source, releases, CI badges</div></div>
-      </a>
-      <a href="https://github.com/Neftedollar/ll-lang/issues" class="link-card" target="_blank" rel="noopener">
-        <span class="l-icon">&#x1F41B;</span>
-        <div><div class="l-title">Issues</div><div class="l-desc">Bug reports and feature requests</div></div>
-      </a>
-      <a href="https://github.com/Neftedollar/ll-lang/discussions" class="link-card" target="_blank" rel="noopener">
-        <span class="l-icon">&#x1F4AC;</span>
-        <div><div class="l-title">Discussions</div><div class="l-desc">Questions, ideas, showcase</div></div>
-      </a>
-      <a href="docs.html" class="link-card">
-        <span class="l-icon">&#x1F4DA;</span>
-        <div><div class="l-title">Documentation</div><div class="l-desc">Spec, stdlib reference, guides</div></div>
-      </a>
-    </div>
-  </div>
-</section>
+    <!-- Community -->
+    <section id="community">
+      <div class="container">
+        <div class="section-label">Community</div>
+        <h2 class="section-title">Get involved</h2>
+        <div class="links-grid">
+          <a
+            href="https://github.com/Neftedollar/ll-lang"
+            class="link-card"
+            target="_blank"
+            rel="noopener"
+          >
+            <span class="l-icon">&#x2605;</span>
+            <div>
+              <div class="l-title">GitHub</div>
+              <div class="l-desc">Source, releases, CI badges</div>
+            </div>
+          </a>
+          <a
+            href="https://github.com/Neftedollar/ll-lang/issues"
+            class="link-card"
+            target="_blank"
+            rel="noopener"
+          >
+            <span class="l-icon">&#x1F41B;</span>
+            <div>
+              <div class="l-title">Issues</div>
+              <div class="l-desc">Bug reports and feature requests</div>
+            </div>
+          </a>
+          <a
+            href="https://github.com/Neftedollar/ll-lang/discussions"
+            class="link-card"
+            target="_blank"
+            rel="noopener"
+          >
+            <span class="l-icon">&#x1F4AC;</span>
+            <div>
+              <div class="l-title">Discussions</div>
+              <div class="l-desc">Questions, ideas, showcase</div>
+            </div>
+          </a>
+          <a href="docs.html" class="link-card">
+            <span class="l-icon">&#x1F4DA;</span>
+            <div>
+              <div class="l-title">Documentation</div>
+              <div class="l-desc">Spec, stdlib reference, guides</div>
+            </div>
+          </a>
+        </div>
+      </div>
+    </section>
 
-<!-- Footer -->
-<footer>
-  <div class="footer-inner">
-    <span class="footer-logo"><span>//</span>ll-lang</span>
-    <ul class="footer-links">
-      <li><a href="https://github.com/Neftedollar/ll-lang" target="_blank" rel="noopener">GitHub</a></li>
-      <li><a href="docs.html">Docs</a></li>
-      <li><a href="playground.html">Playground</a></li>
-      <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a></li>
-    </ul>
-    <p class="footer-copy">&copy; 2025 Neftedollar &mdash; ll-lang v1.0.0</p>
-  </div>
-</footer>
+    <!-- Footer -->
+    <footer>
+      <div class="footer-inner">
+        <span class="footer-logo"><span>//</span>ll-lang</span>
+        <ul class="footer-links">
+          <li>
+            <a
+              href="https://github.com/Neftedollar/ll-lang"
+              target="_blank"
+              rel="noopener"
+              >GitHub</a
+            >
+          </li>
+          <li><a href="docs.html">Docs</a></li>
+          <li><a href="playground.html">Playground</a></li>
+          <li>
+            <a
+              href="https://github.com/Neftedollar/ll-lang/blob/main/LICENSE"
+              target="_blank"
+              rel="noopener"
+              >MIT License</a
+            >
+          </li>
+        </ul>
+        <p class="footer-copy">
+          &copy; 2025 Neftedollar &mdash; ll-lang v1.0.0
+        </p>
+      </div>
+    </footer>
 
-<script>hljs.highlightAll();</script>
-<script src="js/main.js"></script>
-</body>
+    <script>
+      hljs.highlightAll();
+    </script>
+    <script src="js/main.js"></script>
+  </body>
 </html>

--- a/docs-site/index.html
+++ b/docs-site/index.html
@@ -1,190 +1,140 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>
-      ll-lang — The language built for LLMs to write, compile, and fix
-    </title>
-    <meta
-      name="description"
-      content="Token-efficient functional syntax. Machine-readable errors. Compiles to F#, TypeScript, Python, Java, C#."
-    />
-    <meta property="og:title" content="ll-lang" />
-    <meta
-      property="og:description"
-      content="The language built for LLMs to write, compile, and fix."
-    />
-    <meta property="og:type" content="website" />
-    <link rel="stylesheet" href="css/style.css" />
-    <!-- highlight.js -->
-    <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css"
-      integrity="sha384-wH75j6z1lH97ZOpMOInqhgKzFkAInZPPSPlZpYKYTOqsaizPvhQZmAtLcPKXpLyH"
-      crossorigin="anonymous"
-    />
-    <script
-      src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"
-      integrity="sha384-F/bZzf7p3Joyp5psL90p/p89AZJsndkSoGwRpXcZhleCWhd8SnRuoYo4d0yirjJp"
-      crossorigin="anonymous"
-    ></script>
-  </head>
-  <body>
-    <!-- ── Nav ──────────────────────────────────────────────────────────── -->
-    <nav>
-      <div class="nav-inner">
-        <a href="index.html" class="nav-logo"> <span>//</span>ll-lang </a>
-        <ul class="nav-links" id="nav-links">
-          <li><a href="index.html">Home</a></li>
-          <li><a href="docs.html">Docs</a></li>
-          <li><a href="playground.html">Playground</a></li>
-          <li>
-            <a
-              href="https://github.com/Neftedollar/ll-lang"
-              target="_blank"
-              rel="noopener"
-              >GitHub</a
-            >
-          </li>
-          <li>
-            <a
-              href="https://github.com/Neftedollar/ll-lang/releases"
-              class="nav-cta"
-              target="_blank"
-              rel="noopener"
-              >v1.0.0</a
-            >
-          </li>
-        </ul>
-        <button
-          class="nav-hamburger"
-          id="nav-hamburger"
-          aria-label="Toggle navigation"
-          aria-expanded="false"
-        >
-          <span></span><span></span><span></span>
-        </button>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ll-lang &mdash; The language built for LLMs to write, compile, and fix</title>
+  <meta name="description" content="Token-efficient functional syntax. Machine-readable errors. Compiles to F#, TypeScript, Python, Java, C#." />
+  <meta property="og:title" content="ll-lang" />
+  <meta property="og:description" content="The language built for LLMs to write, compile, and fix." />
+  <meta property="og:type" content="website" />
+  <link rel="stylesheet" href="css/style.css" />
+  <link
+    rel="stylesheet"
+    href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css"
+    integrity="sha384-wH75j6z1lH97ZOpMOInqhgKzFkAInZPPSPlZpYKYTOqsaizPvhQZmAtLcPKXpLyH"
+    crossorigin="anonymous"
+  />
+  <script
+    src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"
+    integrity="sha384-F/bZzf7p3Joyp5psL90p/p89AZJsndkSoGwRpXcZhleCWhd8SnRuoYo4d0yirjJp"
+    crossorigin="anonymous"
+  ></script>
+</head>
+<body>
+
+<!-- Nav -->
+<nav>
+  <div class="nav-inner">
+    <a href="index.html" class="nav-logo"><span>//</span>ll-lang</a>
+    <ul class="nav-links" id="nav-links">
+      <li><a href="index.html">Home</a></li>
+      <li><a href="docs.html">Docs</a></li>
+      <li><a href="playground.html">Playground</a></li>
+      <li><a href="https://github.com/Neftedollar/ll-lang" target="_blank" rel="noopener">GitHub</a></li>
+      <li><a href="https://github.com/Neftedollar/ll-lang/releases" class="nav-cta" target="_blank" rel="noopener">v1.0.0</a></li>
+    </ul>
+    <button class="nav-hamburger" id="nav-hamburger" aria-label="Toggle navigation" aria-expanded="false">
+      <span></span><span></span><span></span>
+    </button>
+  </div>
+</nav>
+
+<!-- Hero -->
+<section class="hero">
+  <div class="container">
+    <div class="hero-badge">
+      <span class="dot"></span>v1.0.0 &mdash; Bootstrap fixpoint achieved
+    </div>
+    <h1>The language built for LLMs to write, compile, and fix</h1>
+    <p class="hero-sub">
+      Token-efficient functional syntax. Machine-readable errors.
+      Compiles to F#, TypeScript, Python, Java, C#.
+    </p>
+    <div class="hero-actions">
+      <a href="playground.html" class="btn btn-primary">&#x25B6; Try with lllc</a>
+      <a href="https://github.com/Neftedollar/ll-lang" class="btn btn-secondary" target="_blank" rel="noopener">&#x2605; View on GitHub</a>
+      <a href="docs.html" class="btn btn-ghost">Read the docs &rarr;</a>
+    </div>
+
+    <!-- Terminal mockup -->
+    <div class="hero-terminal">
+      <div class="terminal-bar">
+        <span class="dot red"></span>
+        <span class="dot yellow"></span>
+        <span class="dot green"></span>
+        <span class="terminal-title">hello.lll</span>
       </div>
-    </nav>
+      <div class="terminal-body">
+        <div><span class="t-keyword">module</span> Hello</div>
+        <div>&nbsp;</div>
+        <div><span class="t-comment">-- no fn keyword, no braces, no ceremony</span></div>
+        <div>greet(name <span class="t-type">Str</span>) = <span class="t-keyword">printfn</span> <span class="t-string">"Hello, %s!"</span> name</div>
+        <div>&nbsp;</div>
+        <div>Hello = greet <span class="t-string">"ll-lang"</span></div>
+        <div>&nbsp;</div>
+        <div><span class="t-prompt">$</span> lllc run hello.lll</div>
+        <div><span class="t-success">Hello, ll-lang!</span></div>
+      </div>
+    </div>
+  </div>
+</section>
 
-    <!-- ── Hero ─────────────────────────────────────────────────────────── -->
-    <section class="hero">
-      <div class="container">
-        <div class="hero-badge">
-          <span class="dot"></span>v1.0.0 · Bootstrap fixpoint achieved
-        </div>
+<!-- Stats -->
+<section style="padding-block: 0 4rem">
+  <div class="container">
+    <div class="stats-bar">
+      <div class="stat-item">
+        <div class="stat-value">5,857</div>
+        <div class="stat-label">LOC self-hosted stdlib</div>
+      </div>
+      <div class="stat-item">
+        <div class="stat-value">10</div>
+        <div class="stat-label">stdlib modules</div>
+      </div>
+      <div class="stat-item">
+        <div class="stat-value">5</div>
+        <div class="stat-label">compile targets</div>
+      </div>
+      <div class="stat-item">
+        <div class="stat-value">15</div>
+        <div class="stat-label">keywords total</div>
+      </div>
+      <div class="stat-item">
+        <div class="stat-value">8&ndash;17%</div>
+        <div class="stat-label">fewer tokens vs F#</div>
+      </div>
+    </div>
+  </div>
+</section>
 
-        <h1>The language built for LLMs to write, compile, and fix</h1>
+<div class="divider"></div>
 
-        <p class="hero-sub">
-          Token-efficient functional syntax. Machine-readable errors. Compiles
-          to F#, TypeScript, Python, Java, C#.
+<!-- Features -->
+<section id="features">
+  <div class="container">
+    <div class="section-label">Features</div>
+    <h2 class="section-title">Built differently, on purpose</h2>
+    <p class="section-sub">
+      Every design decision is evaluated against one goal: LLM agents
+      writing correct code on the first attempt.
+    </p>
+
+    <div class="features-grid">
+
+      <!-- Feature 1: Zero ceremony -->
+      <div class="feature-card">
+        <div class="feature-icon">&#x26A1;</div>
+        <h3>Zero ceremony</h3>
+        <p>
+          No <code>fn</code>, <code>type</code>, <code>in</code>, <code>then</code>,
+          or <code>with</code> keywords. Uppercase declares types; lowercase declares
+          values. The body follows <code>=</code>.
         </p>
-
-        <div class="hero-actions">
-          <a href="playground.html" class="btn btn-primary">
-            &#x25B6; Try with lllc
-          </a>
-          <a
-            href="https://github.com/Neftedollar/ll-lang"
-            class="btn btn-secondary"
-            target="_blank"
-            rel="noopener"
-          >
-            &#x2605; View on GitHub
-          </a>
-          <a href="docs.html" class="btn btn-ghost">Read the docs &rarr;</a>
-        </div>
-
-        <!-- Terminal mockup -->
-        <div class="hero-terminal">
-          <div class="terminal-bar">
-            <span class="dot red"></span>
-            <span class="dot yellow"></span>
-            <span class="dot green"></span>
-            <span class="terminal-title">hello.lll</span>
-          </div>
-          <div class="terminal-body">
-            <div><span class="t-keyword">module</span> Hello</div>
-            <div>&nbsp;</div>
-            <div>
-              <span class="t-comment"
-                >-- no fn keyword, no braces, no ceremony</span
-              >
-            </div>
-            <div>
-              greet(name <span class="t-type">Str</span>) =
-              <span class="t-keyword">printfn</span>
-              <span class="t-string">"Hello, %s!"</span> name
-            </div>
-            <div>&nbsp;</div>
-            <div>Hello = greet <span class="t-string">"ll-lang"</span></div>
-            <div>&nbsp;</div>
-            <div><span class="t-prompt">$</span> lllc run hello.lll</div>
-            <div><span class="t-success">Hello, ll-lang!</span></div>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- ── Stats ─────────────────────────────────────────────────────────── -->
-    <section style="padding-block: 0 4rem">
-      <div class="container">
-        <div class="stats-bar">
-          <div class="stat-item">
-            <div class="stat-value">5,857</div>
-            <div class="stat-label">LOC self-hosted stdlib</div>
-          </div>
-          <div class="stat-item">
-            <div class="stat-value">10</div>
-            <div class="stat-label">stdlib modules</div>
-          </div>
-          <div class="stat-item">
-            <div class="stat-value">5</div>
-            <div class="stat-label">compile targets</div>
-          </div>
-          <div class="stat-item">
-            <div class="stat-value">15</div>
-            <div class="stat-label">keywords total</div>
-          </div>
-          <div class="stat-item">
-            <div class="stat-value">8–17%</div>
-            <div class="stat-label">fewer tokens vs F#</div>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <div class="divider"></div>
-
-    <!-- ── Features ─────────────────────────────────────────────────────── -->
-    <section id="features">
-      <div class="container">
-        <div class="section-label">Features</div>
-        <h2 class="section-title">Built differently, on purpose</h2>
-        <p class="section-sub">
-          Every design decision is evaluated against one goal: LLM agents
-          writing correct code on the first attempt.
-        </p>
-
-        <div class="features-grid">
-          <!-- Feature 1: Zero ceremony -->
-          <div class="feature-card">
-            <div class="feature-icon">&#x26A1;</div>
-            <h3>Zero ceremony</h3>
-            <p>
-              No <code>fn</code>, <code>type</code>, <code>in</code>,
-              <code>then</code>, or <code>with</code> keywords. Uppercase
-              declares types; lowercase declares values. The body follows
-              <code>=</code>.
-            </p>
-            <div class="code-compare">
-              <div class="code-block">
-                <div class="compare-label">
-                  <span class="badge badge-before">verbose</span>TypeScript
-                </div>
-                <pre><code class="language-typescript">type Shape =
+        <div class="code-compare">
+          <div class="code-block">
+            <div class="compare-label"><span class="badge badge-before">verbose</span>TypeScript</div>
+            <pre><code class="language-typescript">type Shape =
   | { kind: "Circle"; r: number }
   | { kind: "Rect"; w: number; h: number }
 
@@ -194,217 +144,180 @@ function area(s: Shape): number {
     case "Rect":   return s.w * s.h;
   }
 }</code></pre>
-              </div>
-              <div class="code-block">
-                <div class="compare-label">
-                  <span class="badge badge-after">ll-lang</span>ll-lang
-                </div>
-                <pre><code class="language-haskell">Shape = Circle Float | Rect Float Float
+          </div>
+          <div class="code-block">
+            <div class="compare-label"><span class="badge badge-after">compact</span>ll-lang</div>
+            <pre><code class="language-haskell">Shape = Circle Float | Rect Float Float
 
 area(s Shape) Float =
   match s with
   | Circle r   -> 3.14159 * r * r
   | Rect w h   -> w * h</code></pre>
-              </div>
-            </div>
           </div>
+        </div>
+      </div>
 
-          <!-- Feature 2: LLM errors -->
-          <div class="feature-card">
-            <div class="feature-icon">&#x1F916;</div>
-            <h3>Errors LLMs understand</h3>
-            <p>
-              All errors are short, structured, and machine-readable. One line
-              per error, parseable by regex — no stack traces, no prose.
-            </p>
-            <div class="code-block">
-              <div class="code-block-header">
-                <span class="code-lang">compiler output</span>
-              </div>
-              <pre><code class="language-plaintext">E001 12:5  TypeMismatch     expected Str[UserId] got Str
+      <!-- Feature 2: LLM errors -->
+      <div class="feature-card">
+        <div class="feature-icon">&#x1F916;</div>
+        <h3>Errors LLMs understand</h3>
+        <p>
+          All errors are short, structured, and machine-readable. One line
+          per error, parseable by regex &mdash; no stack traces, no prose.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">
+            <span class="code-lang">compiler output</span>
+          </div>
+          <pre><code class="language-plaintext">E001 12:5  TypeMismatch     expected Str[UserId] got Str
 E003 15:1  NonExhaustiveMatch Shape missing:Empty
 E004 20:9  UnitMismatch     Float[m] vs Float[s]
 E005  7:14 TagViolation     Str[Email] != Str[UserId]
 E002  8:3  UnboundVar       username</code></pre>
-            </div>
-            <p
-              style="margin-top: 0.75rem; margin-bottom: 0; font-size: 0.85rem"
-            >
-              Format: <code>EXXX line:col ErrorKind details</code> — the agent
-              reads the error, patches the source, recompiles. No scraping.
-            </p>
-          </div>
+        </div>
+        <p style="margin-top:.75rem;margin-bottom:0;font-size:.85rem">
+          Format: <code>EXXX line:col ErrorKind details</code> &mdash; the agent
+          reads the error, patches the source, recompiles. No scraping.
+        </p>
+      </div>
 
-          <!-- Feature 3: Multi-target -->
-          <div class="feature-card">
-            <div class="feature-icon">&#x1F3AF;</div>
-            <h3>Multi-target codegen</h3>
-            <p>
-              Write once in ll-lang. Compile to F#, TypeScript, Python, Java 21,
-              or C# from the same source file — same semantics, idiomatic output
-              per target.
-            </p>
-            <div class="code-block">
-              <div class="code-block-header">
-                <span class="code-lang">shell</span>
-                <button class="copy-btn" title="Copy">copy</button>
-              </div>
-              <pre><code class="language-bash">lllc build --target fs   adts.lll  # → F# discriminated unions
-lllc build --target ts   adts.lll  # → TypeScript sealed interfaces
-lllc build --target py   adts.lll  # → Python @dataclass + Union
-lllc build --target java adts.lll  # → Java 21 sealed interfaces
-lllc build --target cs   adts.lll  # → C# records + interfaces</code></pre>
+      <!-- Feature 3: Multi-target -->
+      <div class="feature-card">
+        <div class="feature-icon">&#x1F3AF;</div>
+        <h3>Multi-target codegen</h3>
+        <p>
+          Write once in ll-lang. Compile to F#, TypeScript, Python, Java 21,
+          or C# from the same source &mdash; same semantics, idiomatic output
+          per target.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">
+            <span class="code-lang">shell</span>
+            <button class="copy-btn">copy</button>
+          </div>
+          <pre><code class="language-bash">lllc build --target fs   adts.lll  # F# discriminated unions
+lllc build --target ts   adts.lll  # TypeScript sealed interfaces
+lllc build --target py   adts.lll  # Python @dataclass + Union
+lllc build --target java adts.lll  # Java 21 sealed interfaces
+lllc build --target cs   adts.lll  # C# records + interfaces</code></pre>
+        </div>
+        <div class="targets-grid" style="margin-top:1rem">
+          <div class="target-card"><div class="t-icon">&#x1F4B3;</div><div class="t-name">F#</div><div class="t-flag">--target fs</div><span class="t-stable stable">stable</span></div>
+          <div class="target-card"><div class="t-icon">&#x1F4D8;</div><div class="t-name">TypeScript</div><div class="t-flag">--target ts</div><span class="t-stable stable">stable</span></div>
+          <div class="target-card"><div class="t-icon">&#x1F40D;</div><div class="t-name">Python</div><div class="t-flag">--target py</div><span class="t-stable stable">stable</span></div>
+          <div class="target-card"><div class="t-icon">&#x2615;</div><div class="t-name">Java 21</div><div class="t-flag">--target java</div><span class="t-stable stable">stable</span></div>
+          <div class="target-card"><div class="t-icon">&#x1F4E6;</div><div class="t-name">C#</div><div class="t-flag">--target cs</div><span class="t-stable stable">stable</span></div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</section>
+
+<div class="divider"></div>
+
+<!-- Quickstart -->
+<section id="quickstart">
+  <div class="container">
+    <div class="section-label">Quickstart</div>
+    <h2 class="section-title">Up in 60 seconds</h2>
+    <p class="section-sub">
+      Requires <a href="https://dotnet.microsoft.com/download" target="_blank" rel="noopener">.NET 10</a>.
+    </p>
+
+    <div class="quickstart-steps">
+
+      <div class="qs-step">
+        <div class="qs-num">1</div>
+        <div class="qs-content">
+          <h3>Get the compiler</h3>
+          <div class="code-block">
+            <div class="code-block-header">
+              <span class="code-lang">shell</span>
+              <button class="copy-btn">copy</button>
             </div>
-            <div class="targets-grid" style="margin-top: 1rem">
-              <div class="target-card">
-                <div class="t-icon">&#x1F4B3;</div>
-                <div class="t-name">F#</div>
-                <div class="t-flag">--target fs</div>
-                <span class="t-stable stable">stable</span>
-              </div>
-              <div class="target-card">
-                <div class="t-icon">&#x1F4D8;</div>
-                <div class="t-name">TypeScript</div>
-                <div class="t-flag">--target ts</div>
-                <span class="t-stable stable">stable</span>
-              </div>
-              <div class="target-card">
-                <div class="t-icon">&#x1F40D;</div>
-                <div class="t-name">Python</div>
-                <div class="t-flag">--target py</div>
-                <span class="t-stable stable">stable</span>
-              </div>
-              <div class="target-card">
-                <div class="t-icon">&#x2615;</div>
-                <div class="t-name">Java 21</div>
-                <div class="t-flag">--target java</div>
-                <span class="t-stable stable">stable</span>
-              </div>
-              <div class="target-card">
-                <div class="t-icon">&#x1F4E6;</div>
-                <div class="t-name">C#</div>
-                <div class="t-flag">--target cs</div>
-                <span class="t-stable stable">stable</span>
-              </div>
-            </div>
+            <pre><code class="language-bash">git clone https://github.com/Neftedollar/ll-lang.git
+cd ll-lang
+dotnet build
+dotnet test   # optional: run full test suite</code></pre>
           </div>
         </div>
       </div>
-    </section>
 
-    <div class="divider"></div>
-
-    <!-- ── Quickstart ────────────────────────────────────────────────────── -->
-    <section id="quickstart">
-      <div class="container">
-        <div class="section-label">Quickstart</div>
-        <h2 class="section-title">Up in 60 seconds</h2>
-        <p class="section-sub">
-          Requires
-          <a
-            href="https://dotnet.microsoft.com/download"
-            target="_blank"
-            rel="noopener"
-            >.NET 10</a
-          >.
-        </p>
-
-        <div class="quickstart-steps">
-          <!-- Step 1 -->
-          <div class="qs-step">
-            <div class="qs-num">1</div>
-            <div class="qs-content">
-              <h3>Install lllc</h3>
-              <div class="code-block">
-                <div class="code-block-header">
-                  <span class="code-lang">shell</span>
-                  <button class="copy-btn" title="Copy">copy</button>
-                </div>
-                <pre><code class="language-bash"># Option A — from source (recommended while in early access)
-git clone https://github.com/Neftedollar/ll-lang.git
-cd ll-lang
-dotnet build
-dotnet test   # optional: run the full test suite</code></pre>
-              </div>
+      <div class="qs-step">
+        <div class="qs-num">2</div>
+        <div class="qs-content">
+          <h3>Write your first program</h3>
+          <div class="code-block">
+            <div class="code-block-header">
+              <span class="code-lang">hello.lll</span>
+              <button class="copy-btn">copy</button>
             </div>
-          </div>
-
-          <!-- Step 2 -->
-          <div class="qs-step">
-            <div class="qs-num">2</div>
-            <div class="qs-content">
-              <h3>Write your first program</h3>
-              <div class="code-block">
-                <div class="code-block-header">
-                  <span class="code-lang">hello.lll</span>
-                  <button class="copy-btn" title="Copy">copy</button>
-                </div>
-                <pre><code class="language-haskell">module Hello
+            <pre><code class="language-haskell">module Hello
 
 -- greet takes a Str, returns nothing (unit)
 greet(name Str) = printfn "Hello, %s!" name
 
 -- entry point: uppercase name, no args
 Hello = greet "ll-lang"</code></pre>
-              </div>
-            </div>
-          </div>
-
-          <!-- Step 3 -->
-          <div class="qs-step">
-            <div class="qs-num">3</div>
-            <div class="qs-content">
-              <h3>Compile and run</h3>
-              <div class="code-block">
-                <div class="code-block-header">
-                  <span class="code-lang">shell</span>
-                  <button class="copy-btn" title="Copy">copy</button>
-                </div>
-                <pre><code class="language-bash">lllc run hello.lll
-# → Hello, ll-lang!</code></pre>
-              </div>
-            </div>
-          </div>
-
-          <!-- Step 4 -->
-          <div class="qs-step">
-            <div class="qs-num">4</div>
-            <div class="qs-content">
-              <h3>Scaffold a multi-file project</h3>
-              <div class="code-block">
-                <div class="code-block-header">
-                  <span class="code-lang">shell</span>
-                  <button class="copy-btn" title="Copy">copy</button>
-                </div>
-                <pre><code class="language-bash">lllc new myapp          # creates myapp/lll.toml + src/Main.lll
-cd myapp
-lllc build              # → bin/fsharp/myapp.fsproj
-dotnet run --project bin/fsharp/myapp.fsproj</code></pre>
-              </div>
-            </div>
           </div>
         </div>
       </div>
-    </section>
 
-    <div class="divider"></div>
-
-    <!-- ── MCP section ───────────────────────────────────────────────────── -->
-    <section id="mcp">
-      <div class="container">
-        <div class="section-label">MCP Integration</div>
-        <h2 class="section-title">Wire it to your LLM client</h2>
-        <p class="section-sub">
-          ll-lang ships a built-in MCP server. Connect it to Claude Code,
-          Cursor, or Zed — your agent gets structured tools to compile, check,
-          and run ll-lang without parsing shell output.
-        </p>
-        <div class="code-block">
-          <div class="code-block-header">
-            <span class="code-lang">claude_desktop_config.json</span>
-            <button class="copy-btn" title="Copy">copy</button>
+      <div class="qs-step">
+        <div class="qs-num">3</div>
+        <div class="qs-content">
+          <h3>Compile and run</h3>
+          <div class="code-block">
+            <div class="code-block-header">
+              <span class="code-lang">shell</span>
+              <button class="copy-btn">copy</button>
+            </div>
+            <pre><code class="language-bash">lllc run hello.lll
+# Hello, ll-lang!</code></pre>
           </div>
-          <pre><code class="language-json">{
+        </div>
+      </div>
+
+      <div class="qs-step">
+        <div class="qs-num">4</div>
+        <div class="qs-content">
+          <h3>Scaffold a multi-file project</h3>
+          <div class="code-block">
+            <div class="code-block-header">
+              <span class="code-lang">shell</span>
+              <button class="copy-btn">copy</button>
+            </div>
+            <pre><code class="language-bash">lllc new myapp          # creates myapp/lll.toml + src/Main.lll
+cd myapp
+lllc build              # emits bin/fsharp/myapp.fsproj
+dotnet run --project bin/fsharp/myapp.fsproj</code></pre>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</section>
+
+<div class="divider"></div>
+
+<!-- MCP -->
+<section id="mcp">
+  <div class="container">
+    <div class="section-label">MCP Integration</div>
+    <h2 class="section-title">Wire it to your LLM client</h2>
+    <p class="section-sub">
+      ll-lang ships a built-in MCP server. Connect it to Claude Code, Cursor,
+      or Zed &mdash; your agent gets structured tools to compile, check, and
+      run ll-lang without parsing shell output.
+    </p>
+    <div class="code-block">
+      <div class="code-block-header">
+        <span class="code-lang">claude_desktop_config.json</span>
+        <button class="copy-btn">copy</button>
+      </div>
+      <pre><code class="language-json">{
   "mcpServers": {
     "lllc": {
       "command": "dotnet",
@@ -412,106 +325,60 @@ dotnet run --project bin/fsharp/myapp.fsproj</code></pre>
     }
   }
 }</code></pre>
-        </div>
-        <p style="margin-top: 1rem; font-size: 0.9rem">
-          10 MCP tools available:
-          <code>compile_file</code>, <code>compile_source</code>,
-          <code>check_file</code>, <code>check_source</code>,
-          <code>run_file</code>, <code>list_errors</code>,
-          <code>lookup_error</code>, <code>stdlib_search</code>,
-          <code>grammar_lookup</code>, <code>project_info</code>.
-        </p>
-      </div>
-    </section>
+    </div>
+    <p style="margin-top:1rem;font-size:.9rem">
+      10 MCP tools:
+      <code>compile_file</code>, <code>compile_source</code>, <code>check_file</code>,
+      <code>check_source</code>, <code>run_file</code>, <code>list_errors</code>,
+      <code>lookup_error</code>, <code>stdlib_search</code>, <code>grammar_lookup</code>,
+      <code>project_info</code>.
+    </p>
+  </div>
+</section>
 
-    <div class="divider"></div>
+<div class="divider"></div>
 
-    <!-- ── Community ─────────────────────────────────────────────────────── -->
-    <section id="community">
-      <div class="container">
-        <div class="section-label">Community</div>
-        <h2 class="section-title">Get involved</h2>
-        <div class="links-grid">
-          <a
-            href="https://github.com/Neftedollar/ll-lang"
-            class="link-card"
-            target="_blank"
-            rel="noopener"
-          >
-            <span class="l-icon">&#x2605;</span>
-            <div>
-              <div class="l-title">GitHub</div>
-              <div class="l-desc">Source, releases, CI badges</div>
-            </div>
-          </a>
-          <a
-            href="https://github.com/Neftedollar/ll-lang/issues"
-            class="link-card"
-            target="_blank"
-            rel="noopener"
-          >
-            <span class="l-icon">&#x1F41B;</span>
-            <div>
-              <div class="l-title">Issues</div>
-              <div class="l-desc">Bug reports and feature requests</div>
-            </div>
-          </a>
-          <a
-            href="https://github.com/Neftedollar/ll-lang/discussions"
-            class="link-card"
-            target="_blank"
-            rel="noopener"
-          >
-            <span class="l-icon">&#x1F4AC;</span>
-            <div>
-              <div class="l-title">Discussions</div>
-              <div class="l-desc">Questions, ideas, showcase</div>
-            </div>
-          </a>
-          <a href="docs.html" class="link-card">
-            <span class="l-icon">&#x1F4DA;</span>
-            <div>
-              <div class="l-title">Documentation</div>
-              <div class="l-desc">Spec, stdlib reference, guides</div>
-            </div>
-          </a>
-        </div>
-      </div>
-    </section>
+<!-- Community -->
+<section id="community">
+  <div class="container">
+    <div class="section-label">Community</div>
+    <h2 class="section-title">Get involved</h2>
+    <div class="links-grid">
+      <a href="https://github.com/Neftedollar/ll-lang" class="link-card" target="_blank" rel="noopener">
+        <span class="l-icon">&#x2605;</span>
+        <div><div class="l-title">GitHub</div><div class="l-desc">Source, releases, CI badges</div></div>
+      </a>
+      <a href="https://github.com/Neftedollar/ll-lang/issues" class="link-card" target="_blank" rel="noopener">
+        <span class="l-icon">&#x1F41B;</span>
+        <div><div class="l-title">Issues</div><div class="l-desc">Bug reports and feature requests</div></div>
+      </a>
+      <a href="https://github.com/Neftedollar/ll-lang/discussions" class="link-card" target="_blank" rel="noopener">
+        <span class="l-icon">&#x1F4AC;</span>
+        <div><div class="l-title">Discussions</div><div class="l-desc">Questions, ideas, showcase</div></div>
+      </a>
+      <a href="docs.html" class="link-card">
+        <span class="l-icon">&#x1F4DA;</span>
+        <div><div class="l-title">Documentation</div><div class="l-desc">Spec, stdlib reference, guides</div></div>
+      </a>
+    </div>
+  </div>
+</section>
 
-    <!-- ── Footer ────────────────────────────────────────────────────────── -->
-    <footer>
-      <div class="footer-inner">
-        <span class="footer-logo"><span>//</span>ll-lang</span>
-        <ul class="footer-links">
-          <li>
-            <a
-              href="https://github.com/Neftedollar/ll-lang"
-              target="_blank"
-              rel="noopener"
-              >GitHub</a
-            >
-          </li>
-          <li><a href="docs.html">Docs</a></li>
-          <li><a href="playground.html">Playground</a></li>
-          <li>
-            <a
-              href="https://github.com/Neftedollar/ll-lang/blob/main/LICENSE"
-              target="_blank"
-              rel="noopener"
-              >MIT License</a
-            >
-          </li>
-        </ul>
-        <p class="footer-copy">
-          &copy; 2025 Neftedollar &mdash; ll-lang v1.0.0
-        </p>
-      </div>
-    </footer>
+<!-- Footer -->
+<footer>
+  <div class="footer-inner">
+    <span class="footer-logo"><span>//</span>ll-lang</span>
+    <ul class="footer-links">
+      <li><a href="https://github.com/Neftedollar/ll-lang" target="_blank" rel="noopener">GitHub</a></li>
+      <li><a href="docs.html">Docs</a></li>
+      <li><a href="playground.html">Playground</a></li>
+      <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a></li>
+    </ul>
+    <p class="footer-copy">&copy; 2025 Neftedollar &mdash; ll-lang v1.0.0</p>
+  </div>
+</footer>
 
-    <script>
-      hljs.highlightAll();
-    </script>
-    <script src="js/main.js"></script>
-  </body>
+<script>hljs.highlightAll();</script>
+<script src="js/main.js"></script>
+</body>
 </html>

--- a/docs-site/index.html
+++ b/docs-site/index.html
@@ -1,0 +1,517 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>
+      ll-lang — The language built for LLMs to write, compile, and fix
+    </title>
+    <meta
+      name="description"
+      content="Token-efficient functional syntax. Machine-readable errors. Compiles to F#, TypeScript, Python, Java, C#."
+    />
+    <meta property="og:title" content="ll-lang" />
+    <meta
+      property="og:description"
+      content="The language built for LLMs to write, compile, and fix."
+    />
+    <meta property="og:type" content="website" />
+    <link rel="stylesheet" href="css/style.css" />
+    <!-- highlight.js -->
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css"
+      integrity="sha384-wH75j6z1lH97ZOpMOInqhgKzFkAInZPPSPlZpYKYTOqsaizPvhQZmAtLcPKXpLyH"
+      crossorigin="anonymous"
+    />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"
+      integrity="sha384-F/bZzf7p3Joyp5psL90p/p89AZJsndkSoGwRpXcZhleCWhd8SnRuoYo4d0yirjJp"
+      crossorigin="anonymous"
+    ></script>
+  </head>
+  <body>
+    <!-- ── Nav ──────────────────────────────────────────────────────────── -->
+    <nav>
+      <div class="nav-inner">
+        <a href="index.html" class="nav-logo"> <span>//</span>ll-lang </a>
+        <ul class="nav-links" id="nav-links">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="docs.html">Docs</a></li>
+          <li><a href="playground.html">Playground</a></li>
+          <li>
+            <a
+              href="https://github.com/Neftedollar/ll-lang"
+              target="_blank"
+              rel="noopener"
+              >GitHub</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://github.com/Neftedollar/ll-lang/releases"
+              class="nav-cta"
+              target="_blank"
+              rel="noopener"
+              >v1.0.0</a
+            >
+          </li>
+        </ul>
+        <button
+          class="nav-hamburger"
+          id="nav-hamburger"
+          aria-label="Toggle navigation"
+          aria-expanded="false"
+        >
+          <span></span><span></span><span></span>
+        </button>
+      </div>
+    </nav>
+
+    <!-- ── Hero ─────────────────────────────────────────────────────────── -->
+    <section class="hero">
+      <div class="container">
+        <div class="hero-badge">
+          <span class="dot"></span>v1.0.0 · Bootstrap fixpoint achieved
+        </div>
+
+        <h1>The language built for LLMs to write, compile, and fix</h1>
+
+        <p class="hero-sub">
+          Token-efficient functional syntax. Machine-readable errors. Compiles
+          to F#, TypeScript, Python, Java, C#.
+        </p>
+
+        <div class="hero-actions">
+          <a href="playground.html" class="btn btn-primary">
+            &#x25B6; Try with lllc
+          </a>
+          <a
+            href="https://github.com/Neftedollar/ll-lang"
+            class="btn btn-secondary"
+            target="_blank"
+            rel="noopener"
+          >
+            &#x2605; View on GitHub
+          </a>
+          <a href="docs.html" class="btn btn-ghost">Read the docs &rarr;</a>
+        </div>
+
+        <!-- Terminal mockup -->
+        <div class="hero-terminal">
+          <div class="terminal-bar">
+            <span class="dot red"></span>
+            <span class="dot yellow"></span>
+            <span class="dot green"></span>
+            <span class="terminal-title">hello.lll</span>
+          </div>
+          <div class="terminal-body">
+            <div><span class="t-keyword">module</span> Hello</div>
+            <div>&nbsp;</div>
+            <div>
+              <span class="t-comment"
+                >-- no fn keyword, no braces, no ceremony</span
+              >
+            </div>
+            <div>
+              greet(name <span class="t-type">Str</span>) =
+              <span class="t-keyword">printfn</span>
+              <span class="t-string">"Hello, %s!"</span> name
+            </div>
+            <div>&nbsp;</div>
+            <div>Hello = greet <span class="t-string">"ll-lang"</span></div>
+            <div>&nbsp;</div>
+            <div><span class="t-prompt">$</span> lllc run hello.lll</div>
+            <div><span class="t-success">Hello, ll-lang!</span></div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── Stats ─────────────────────────────────────────────────────────── -->
+    <section style="padding-block: 0 4rem">
+      <div class="container">
+        <div class="stats-bar">
+          <div class="stat-item">
+            <div class="stat-value">5,857</div>
+            <div class="stat-label">LOC self-hosted stdlib</div>
+          </div>
+          <div class="stat-item">
+            <div class="stat-value">10</div>
+            <div class="stat-label">stdlib modules</div>
+          </div>
+          <div class="stat-item">
+            <div class="stat-value">5</div>
+            <div class="stat-label">compile targets</div>
+          </div>
+          <div class="stat-item">
+            <div class="stat-value">15</div>
+            <div class="stat-label">keywords total</div>
+          </div>
+          <div class="stat-item">
+            <div class="stat-value">8–17%</div>
+            <div class="stat-label">fewer tokens vs F#</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <div class="divider"></div>
+
+    <!-- ── Features ─────────────────────────────────────────────────────── -->
+    <section id="features">
+      <div class="container">
+        <div class="section-label">Features</div>
+        <h2 class="section-title">Built differently, on purpose</h2>
+        <p class="section-sub">
+          Every design decision is evaluated against one goal: LLM agents
+          writing correct code on the first attempt.
+        </p>
+
+        <div class="features-grid">
+          <!-- Feature 1: Zero ceremony -->
+          <div class="feature-card">
+            <div class="feature-icon">&#x26A1;</div>
+            <h3>Zero ceremony</h3>
+            <p>
+              No <code>fn</code>, <code>type</code>, <code>in</code>,
+              <code>then</code>, or <code>with</code> keywords. Uppercase
+              declares types; lowercase declares values. The body follows
+              <code>=</code>.
+            </p>
+            <div class="code-compare">
+              <div class="code-block">
+                <div class="compare-label">
+                  <span class="badge badge-before">verbose</span>TypeScript
+                </div>
+                <pre><code class="language-typescript">type Shape =
+  | { kind: "Circle"; r: number }
+  | { kind: "Rect"; w: number; h: number }
+
+function area(s: Shape): number {
+  switch (s.kind) {
+    case "Circle": return Math.PI * s.r * s.r;
+    case "Rect":   return s.w * s.h;
+  }
+}</code></pre>
+              </div>
+              <div class="code-block">
+                <div class="compare-label">
+                  <span class="badge badge-after">ll-lang</span>ll-lang
+                </div>
+                <pre><code class="language-haskell">Shape = Circle Float | Rect Float Float
+
+area(s Shape) Float =
+  match s with
+  | Circle r   -> 3.14159 * r * r
+  | Rect w h   -> w * h</code></pre>
+              </div>
+            </div>
+          </div>
+
+          <!-- Feature 2: LLM errors -->
+          <div class="feature-card">
+            <div class="feature-icon">&#x1F916;</div>
+            <h3>Errors LLMs understand</h3>
+            <p>
+              All errors are short, structured, and machine-readable. One line
+              per error, parseable by regex — no stack traces, no prose.
+            </p>
+            <div class="code-block">
+              <div class="code-block-header">
+                <span class="code-lang">compiler output</span>
+              </div>
+              <pre><code class="language-plaintext">E001 12:5  TypeMismatch     expected Str[UserId] got Str
+E003 15:1  NonExhaustiveMatch Shape missing:Empty
+E004 20:9  UnitMismatch     Float[m] vs Float[s]
+E005  7:14 TagViolation     Str[Email] != Str[UserId]
+E002  8:3  UnboundVar       username</code></pre>
+            </div>
+            <p
+              style="margin-top: 0.75rem; margin-bottom: 0; font-size: 0.85rem"
+            >
+              Format: <code>EXXX line:col ErrorKind details</code> — the agent
+              reads the error, patches the source, recompiles. No scraping.
+            </p>
+          </div>
+
+          <!-- Feature 3: Multi-target -->
+          <div class="feature-card">
+            <div class="feature-icon">&#x1F3AF;</div>
+            <h3>Multi-target codegen</h3>
+            <p>
+              Write once in ll-lang. Compile to F#, TypeScript, Python, Java 21,
+              or C# from the same source file — same semantics, idiomatic output
+              per target.
+            </p>
+            <div class="code-block">
+              <div class="code-block-header">
+                <span class="code-lang">shell</span>
+                <button class="copy-btn" title="Copy">copy</button>
+              </div>
+              <pre><code class="language-bash">lllc build --target fs   adts.lll  # → F# discriminated unions
+lllc build --target ts   adts.lll  # → TypeScript sealed interfaces
+lllc build --target py   adts.lll  # → Python @dataclass + Union
+lllc build --target java adts.lll  # → Java 21 sealed interfaces
+lllc build --target cs   adts.lll  # → C# records + interfaces</code></pre>
+            </div>
+            <div class="targets-grid" style="margin-top: 1rem">
+              <div class="target-card">
+                <div class="t-icon">&#x1F4B3;</div>
+                <div class="t-name">F#</div>
+                <div class="t-flag">--target fs</div>
+                <span class="t-stable stable">stable</span>
+              </div>
+              <div class="target-card">
+                <div class="t-icon">&#x1F4D8;</div>
+                <div class="t-name">TypeScript</div>
+                <div class="t-flag">--target ts</div>
+                <span class="t-stable stable">stable</span>
+              </div>
+              <div class="target-card">
+                <div class="t-icon">&#x1F40D;</div>
+                <div class="t-name">Python</div>
+                <div class="t-flag">--target py</div>
+                <span class="t-stable stable">stable</span>
+              </div>
+              <div class="target-card">
+                <div class="t-icon">&#x2615;</div>
+                <div class="t-name">Java 21</div>
+                <div class="t-flag">--target java</div>
+                <span class="t-stable stable">stable</span>
+              </div>
+              <div class="target-card">
+                <div class="t-icon">&#x1F4E6;</div>
+                <div class="t-name">C#</div>
+                <div class="t-flag">--target cs</div>
+                <span class="t-stable stable">stable</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <div class="divider"></div>
+
+    <!-- ── Quickstart ────────────────────────────────────────────────────── -->
+    <section id="quickstart">
+      <div class="container">
+        <div class="section-label">Quickstart</div>
+        <h2 class="section-title">Up in 60 seconds</h2>
+        <p class="section-sub">
+          Requires
+          <a
+            href="https://dotnet.microsoft.com/download"
+            target="_blank"
+            rel="noopener"
+            >.NET 10</a
+          >.
+        </p>
+
+        <div class="quickstart-steps">
+          <!-- Step 1 -->
+          <div class="qs-step">
+            <div class="qs-num">1</div>
+            <div class="qs-content">
+              <h3>Install lllc</h3>
+              <div class="code-block">
+                <div class="code-block-header">
+                  <span class="code-lang">shell</span>
+                  <button class="copy-btn" title="Copy">copy</button>
+                </div>
+                <pre><code class="language-bash"># Option A — from source (recommended while in early access)
+git clone https://github.com/Neftedollar/ll-lang.git
+cd ll-lang
+dotnet build
+dotnet test   # optional: run the full test suite</code></pre>
+              </div>
+            </div>
+          </div>
+
+          <!-- Step 2 -->
+          <div class="qs-step">
+            <div class="qs-num">2</div>
+            <div class="qs-content">
+              <h3>Write your first program</h3>
+              <div class="code-block">
+                <div class="code-block-header">
+                  <span class="code-lang">hello.lll</span>
+                  <button class="copy-btn" title="Copy">copy</button>
+                </div>
+                <pre><code class="language-haskell">module Hello
+
+-- greet takes a Str, returns nothing (unit)
+greet(name Str) = printfn "Hello, %s!" name
+
+-- entry point: uppercase name, no args
+Hello = greet "ll-lang"</code></pre>
+              </div>
+            </div>
+          </div>
+
+          <!-- Step 3 -->
+          <div class="qs-step">
+            <div class="qs-num">3</div>
+            <div class="qs-content">
+              <h3>Compile and run</h3>
+              <div class="code-block">
+                <div class="code-block-header">
+                  <span class="code-lang">shell</span>
+                  <button class="copy-btn" title="Copy">copy</button>
+                </div>
+                <pre><code class="language-bash">lllc run hello.lll
+# → Hello, ll-lang!</code></pre>
+              </div>
+            </div>
+          </div>
+
+          <!-- Step 4 -->
+          <div class="qs-step">
+            <div class="qs-num">4</div>
+            <div class="qs-content">
+              <h3>Scaffold a multi-file project</h3>
+              <div class="code-block">
+                <div class="code-block-header">
+                  <span class="code-lang">shell</span>
+                  <button class="copy-btn" title="Copy">copy</button>
+                </div>
+                <pre><code class="language-bash">lllc new myapp          # creates myapp/lll.toml + src/Main.lll
+cd myapp
+lllc build              # → bin/fsharp/myapp.fsproj
+dotnet run --project bin/fsharp/myapp.fsproj</code></pre>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <div class="divider"></div>
+
+    <!-- ── MCP section ───────────────────────────────────────────────────── -->
+    <section id="mcp">
+      <div class="container">
+        <div class="section-label">MCP Integration</div>
+        <h2 class="section-title">Wire it to your LLM client</h2>
+        <p class="section-sub">
+          ll-lang ships a built-in MCP server. Connect it to Claude Code,
+          Cursor, or Zed — your agent gets structured tools to compile, check,
+          and run ll-lang without parsing shell output.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">
+            <span class="code-lang">claude_desktop_config.json</span>
+            <button class="copy-btn" title="Copy">copy</button>
+          </div>
+          <pre><code class="language-json">{
+  "mcpServers": {
+    "lllc": {
+      "command": "dotnet",
+      "args": ["run", "--project", "/path/to/ll-lang/src/LLLangTool", "--", "mcp"]
+    }
+  }
+}</code></pre>
+        </div>
+        <p style="margin-top: 1rem; font-size: 0.9rem">
+          10 MCP tools available:
+          <code>compile_file</code>, <code>compile_source</code>,
+          <code>check_file</code>, <code>check_source</code>,
+          <code>run_file</code>, <code>list_errors</code>,
+          <code>lookup_error</code>, <code>stdlib_search</code>,
+          <code>grammar_lookup</code>, <code>project_info</code>.
+        </p>
+      </div>
+    </section>
+
+    <div class="divider"></div>
+
+    <!-- ── Community ─────────────────────────────────────────────────────── -->
+    <section id="community">
+      <div class="container">
+        <div class="section-label">Community</div>
+        <h2 class="section-title">Get involved</h2>
+        <div class="links-grid">
+          <a
+            href="https://github.com/Neftedollar/ll-lang"
+            class="link-card"
+            target="_blank"
+            rel="noopener"
+          >
+            <span class="l-icon">&#x2605;</span>
+            <div>
+              <div class="l-title">GitHub</div>
+              <div class="l-desc">Source, releases, CI badges</div>
+            </div>
+          </a>
+          <a
+            href="https://github.com/Neftedollar/ll-lang/issues"
+            class="link-card"
+            target="_blank"
+            rel="noopener"
+          >
+            <span class="l-icon">&#x1F41B;</span>
+            <div>
+              <div class="l-title">Issues</div>
+              <div class="l-desc">Bug reports and feature requests</div>
+            </div>
+          </a>
+          <a
+            href="https://github.com/Neftedollar/ll-lang/discussions"
+            class="link-card"
+            target="_blank"
+            rel="noopener"
+          >
+            <span class="l-icon">&#x1F4AC;</span>
+            <div>
+              <div class="l-title">Discussions</div>
+              <div class="l-desc">Questions, ideas, showcase</div>
+            </div>
+          </a>
+          <a href="docs.html" class="link-card">
+            <span class="l-icon">&#x1F4DA;</span>
+            <div>
+              <div class="l-title">Documentation</div>
+              <div class="l-desc">Spec, stdlib reference, guides</div>
+            </div>
+          </a>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── Footer ────────────────────────────────────────────────────────── -->
+    <footer>
+      <div class="footer-inner">
+        <span class="footer-logo"><span>//</span>ll-lang</span>
+        <ul class="footer-links">
+          <li>
+            <a
+              href="https://github.com/Neftedollar/ll-lang"
+              target="_blank"
+              rel="noopener"
+              >GitHub</a
+            >
+          </li>
+          <li><a href="docs.html">Docs</a></li>
+          <li><a href="playground.html">Playground</a></li>
+          <li>
+            <a
+              href="https://github.com/Neftedollar/ll-lang/blob/main/LICENSE"
+              target="_blank"
+              rel="noopener"
+              >MIT License</a
+            >
+          </li>
+        </ul>
+        <p class="footer-copy">
+          &copy; 2025 Neftedollar &mdash; ll-lang v1.0.0
+        </p>
+      </div>
+    </footer>
+
+    <script>
+      hljs.highlightAll();
+    </script>
+    <script src="js/main.js"></script>
+  </body>
+</html>

--- a/docs-site/js/main.js
+++ b/docs-site/js/main.js
@@ -1,0 +1,70 @@
+/* ll-lang docs — main.js */
+
+// ── Mobile nav toggle ────────────────────────────────────────────────────────
+(function () {
+  const hamburger = document.getElementById("nav-hamburger");
+  const navLinks = document.getElementById("nav-links");
+  if (!hamburger || !navLinks) return;
+
+  hamburger.addEventListener("click", () => {
+    const open = navLinks.classList.toggle("open");
+    hamburger.setAttribute("aria-expanded", open);
+  });
+
+  // Close on outside click
+  document.addEventListener("click", (e) => {
+    if (!hamburger.contains(e.target) && !navLinks.contains(e.target)) {
+      navLinks.classList.remove("open");
+      hamburger.setAttribute("aria-expanded", false);
+    }
+  });
+})();
+
+// ── Copy buttons ─────────────────────────────────────────────────────────────
+(function () {
+  document.querySelectorAll(".copy-btn").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const block = btn.closest(".code-block");
+      const code = block ? block.querySelector("code") : null;
+      if (!code) return;
+
+      navigator.clipboard
+        .writeText(code.innerText)
+        .then(() => {
+          const orig = btn.textContent;
+          btn.textContent = "copied!";
+          setTimeout(() => (btn.textContent = orig), 1800);
+        })
+        .catch(() => {
+          // clipboard API unavailable — select text as fallback
+          const range = document.createRange();
+          range.selectNodeContents(code);
+          const sel = window.getSelection();
+          sel.removeAllRanges();
+          sel.addRange(range);
+        });
+    });
+  });
+})();
+
+// ── Active nav link ──────────────────────────────────────────────────────────
+(function () {
+  const page = location.pathname.split("/").pop() || "index.html";
+  document.querySelectorAll(".nav-links a").forEach((a) => {
+    const href = a.getAttribute("href");
+    if (href === page || (page === "" && href === "index.html")) {
+      a.classList.add("active");
+    }
+  });
+})();
+
+// ── Scroll-based nav shadow ──────────────────────────────────────────────────
+(function () {
+  const nav = document.querySelector("nav");
+  if (!nav) return;
+  const onScroll = () => {
+    nav.style.boxShadow =
+      window.scrollY > 10 ? "0 1px 24px rgba(0,0,0,.5)" : "";
+  };
+  window.addEventListener("scroll", onScroll, { passive: true });
+})();

--- a/docs-site/js/main.js
+++ b/docs-site/js/main.js
@@ -1,70 +1,60 @@
 /* ll-lang docs — main.js */
 
-// ── Mobile nav toggle ────────────────────────────────────────────────────────
+// Mobile nav toggle
 (function () {
-  const hamburger = document.getElementById("nav-hamburger");
-  const navLinks = document.getElementById("nav-links");
+  var hamburger = document.getElementById('nav-hamburger');
+  var navLinks  = document.getElementById('nav-links');
   if (!hamburger || !navLinks) return;
-
-  hamburger.addEventListener("click", () => {
-    const open = navLinks.classList.toggle("open");
-    hamburger.setAttribute("aria-expanded", open);
+  hamburger.addEventListener('click', function () {
+    var open = navLinks.classList.toggle('open');
+    hamburger.setAttribute('aria-expanded', open);
   });
-
-  // Close on outside click
-  document.addEventListener("click", (e) => {
+  document.addEventListener('click', function (e) {
     if (!hamburger.contains(e.target) && !navLinks.contains(e.target)) {
-      navLinks.classList.remove("open");
-      hamburger.setAttribute("aria-expanded", false);
+      navLinks.classList.remove('open');
+      hamburger.setAttribute('aria-expanded', false);
     }
   });
 })();
 
-// ── Copy buttons ─────────────────────────────────────────────────────────────
+// Copy buttons
 (function () {
-  document.querySelectorAll(".copy-btn").forEach((btn) => {
-    btn.addEventListener("click", () => {
-      const block = btn.closest(".code-block");
-      const code = block ? block.querySelector("code") : null;
+  document.querySelectorAll('.copy-btn').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      var block = btn.closest('.code-block');
+      var code  = block ? block.querySelector('code') : null;
       if (!code) return;
-
-      navigator.clipboard
-        .writeText(code.innerText)
-        .then(() => {
-          const orig = btn.textContent;
-          btn.textContent = "copied!";
-          setTimeout(() => (btn.textContent = orig), 1800);
-        })
-        .catch(() => {
-          // clipboard API unavailable — select text as fallback
-          const range = document.createRange();
-          range.selectNodeContents(code);
-          const sel = window.getSelection();
-          sel.removeAllRanges();
-          sel.addRange(range);
-        });
+      navigator.clipboard.writeText(code.innerText).then(function () {
+        var orig = btn.textContent;
+        btn.textContent = 'copied!';
+        setTimeout(function () { btn.textContent = orig; }, 1800);
+      }).catch(function () {
+        var range = document.createRange();
+        range.selectNodeContents(code);
+        var sel = window.getSelection();
+        sel.removeAllRanges();
+        sel.addRange(range);
+      });
     });
   });
 })();
 
-// ── Active nav link ──────────────────────────────────────────────────────────
+// Active nav link
 (function () {
-  const page = location.pathname.split("/").pop() || "index.html";
-  document.querySelectorAll(".nav-links a").forEach((a) => {
-    const href = a.getAttribute("href");
-    if (href === page || (page === "" && href === "index.html")) {
-      a.classList.add("active");
+  var page = location.pathname.split('/').pop() || 'index.html';
+  document.querySelectorAll('.nav-links a').forEach(function (a) {
+    var href = a.getAttribute('href');
+    if (href === page || (page === '' && href === 'index.html')) {
+      a.classList.add('active');
     }
   });
 })();
 
-// ── Scroll-based nav shadow ──────────────────────────────────────────────────
+// Scroll nav shadow
 (function () {
-  const nav = document.querySelector("nav");
+  var nav = document.querySelector('nav');
   if (!nav) return;
-  const onScroll = () => {
-    nav.style.boxShadow =
-      window.scrollY > 10 ? "0 1px 24px rgba(0,0,0,.5)" : "";
-  };
-  window.addEventListener("scroll", onScroll, { passive: true });
+  window.addEventListener('scroll', function () {
+    nav.style.boxShadow = window.scrollY > 10 ? '0 1px 24px rgba(0,0,0,.5)' : '';
+  }, { passive: true });
 })();

--- a/docs-site/llms.txt
+++ b/docs-site/llms.txt
@@ -63,7 +63,7 @@ lllc mcp                         # start MCP server
 
 ## MCP server
 ll-lang ships with a built-in MCP (Model Context Protocol) server: `lllc mcp`
-Tools: compile_file, check_file, run_file, list_errors, lookup_error, stdlib_search, grammar_lookup
+Tools: compile_file, check_file, run_file, compile_source, check_source, list_errors, lookup_error, stdlib_search, grammar_lookup, project_info
 
 ## Links
 - GitHub: https://github.com/Neftedollar/ll-lang

--- a/docs-site/llms.txt
+++ b/docs-site/llms.txt
@@ -1,0 +1,73 @@
+# ll-lang
+
+> A statically-typed functional language designed for LLM code generation.
+> Token-efficient syntax. Compiled = works. Errors your agent can parse.
+
+## What is ll-lang?
+
+ll-lang is a functional programming language with Hindley-Milner type inference, designed specifically for use with large language models (LLMs). Its syntax removes ceremony keywords (`fn`, `type`, `let`) that waste tokens without adding meaning.
+
+## Key properties
+
+- **Token efficiency**: 8-17% more compact than F#, 1.3-5.9x more compact than TypeScript/Python/Java on type-heavy code
+- **Machine-readable errors**: All diagnostics follow `EXXX line:col Name details` format (e.g., `E001 3:5 TypeMismatch expected Int got Str`)
+- **Multi-target codegen**: One .lll source -> F# (default), TypeScript, Python, Java, C#
+- **Static typing**: Hindley-Milner inference with rank-1 polymorphism
+- **Self-hosted**: 10 stdlib modules (5857 LOC) written in ll-lang itself
+
+## Syntax examples
+
+### Hello world
+```
+module Hello
+main() = printfn "Hello!"
+```
+
+### Functions
+```
+add(a Int)(b Int) = a + b
+```
+
+### Types (ADTs)
+```
+Shape = Circle Float | Rect Float Float
+
+area(s Shape) =
+  match s
+    | Circle r -> 3.14159 * r * r
+    | Rect w h -> w * h
+```
+
+### Generic map
+```
+map(f A -> B)(xs List[A]) List[B] =
+  match xs
+    | [] -> []
+    | h :: t -> f h :: map f t
+```
+
+## Error format (machine-readable)
+```
+E001 3:5 TypeMismatch expected Int got Str
+E002 7:1 UnboundVar `processInput` is not defined
+E003 12:3 NonExhaustiveMatch missing pattern `None`
+```
+
+## CLI usage
+```
+lllc run hello.lll               # compile and run
+lllc build --target ts hello.lll  # compile to TypeScript
+lllc check hello.lll             # type-check only
+lllc mcp                         # start MCP server
+```
+
+## MCP server
+ll-lang ships with a built-in MCP (Model Context Protocol) server: `lllc mcp`
+Tools: compile_file, check_file, run_file, list_errors, lookup_error, stdlib_search, grammar_lookup
+
+## Links
+- GitHub: https://github.com/Neftedollar/ll-lang
+- Documentation: https://neftedollar.github.io/ll-lang/docs.html
+- Language spec: https://github.com/Neftedollar/ll-lang/blob/main/docs/language-spec.md
+- Error codes: https://github.com/Neftedollar/ll-lang/blob/main/spec/error-codes.md
+- LLM best practices: https://github.com/Neftedollar/ll-lang/blob/main/docs/llm-best-practices.md

--- a/docs-site/playground.html
+++ b/docs-site/playground.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Playground &mdash; ll-lang</title>
+  <meta name="description" content="Try ll-lang in your terminal using the lllc CLI." />
+  <link rel="stylesheet" href="css/style.css" />
+  <link
+    rel="stylesheet"
+    href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css"
+    integrity="sha384-wH75j6z1lH97ZOpMOInqhgKzFkAInZPPSPlZpYKYTOqsaizPvhQZmAtLcPKXpLyH"
+    crossorigin="anonymous"
+  />
+  <script
+    src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"
+    integrity="sha384-F/bZzf7p3Joyp5psL90p/p89AZJsndkSoGwRpXcZhleCWhd8SnRuoYo4d0yirjJp"
+    crossorigin="anonymous"
+  ></script>
+</head>
+<body>
+
+<!-- Nav -->
+<nav>
+  <div class="nav-inner">
+    <a href="index.html" class="nav-logo"><span>//</span>ll-lang</a>
+    <ul class="nav-links" id="nav-links">
+      <li><a href="index.html">Home</a></li>
+      <li><a href="docs.html">Docs</a></li>
+      <li><a href="playground.html">Playground</a></li>
+      <li><a href="https://github.com/Neftedollar/ll-lang" target="_blank" rel="noopener">GitHub</a></li>
+      <li><a href="https://github.com/Neftedollar/ll-lang/releases" class="nav-cta" target="_blank" rel="noopener">v1.0.0</a></li>
+    </ul>
+    <button class="nav-hamburger" id="nav-hamburger" aria-label="Toggle navigation" aria-expanded="false">
+      <span></span><span></span><span></span>
+    </button>
+  </div>
+</nav>
+
+<!-- Hero -->
+<section style="padding-block:4rem 2rem;text-align:center">
+  <div class="container">
+    <div class="section-label">Playground</div>
+    <h1 style="font-size:clamp(1.8rem,4vw,2.6rem);margin-bottom:1rem">Try ll-lang</h1>
+    <p style="max-width:52ch;margin-inline:auto;font-size:1.05rem;margin-bottom:3rem">
+      A browser-based playground is on the roadmap. For now, run ll-lang
+      locally in under a minute using <code>lllc</code>.
+    </p>
+
+    <div class="coming-soon-card">
+      <div class="icon">&#x1F4BB;</div>
+      <h2>Run it locally</h2>
+      <p>
+        The fastest way to try ll-lang is the CLI. Clone the repo,
+        build once, then use <code>lllc run</code> or <code>lllc check</code>
+        on any <code>.lll</code> file.
+      </p>
+      <a
+        href="https://github.com/Neftedollar/ll-lang"
+        class="btn btn-primary"
+        target="_blank"
+        rel="noopener"
+        style="display:inline-flex;margin-bottom:1rem"
+      >
+        &#x2605; Get lllc on GitHub
+      </a>
+      <p style="font-size:.85rem;color:var(--text-muted)">
+        Online playground coming in a future release.
+      </p>
+    </div>
+  </div>
+</section>
+
+<div class="divider"></div>
+
+<!-- Runnable examples -->
+<section>
+  <div class="container">
+    <div class="section-label">Examples</div>
+    <h2 class="section-title">Try these snippets</h2>
+    <p class="section-sub">Copy any snippet, save it as <code>example.lll</code>, and run <code>lllc run example.lll</code>.</p>
+
+    <div style="display:flex;flex-direction:column;gap:2rem">
+
+      <!-- Hello World -->
+      <div>
+        <h3 style="color:var(--text-primary);margin-bottom:.75rem">Hello, world</h3>
+        <div class="code-block">
+          <div class="code-block-header">
+            <span class="code-lang">hello.lll</span>
+            <button class="copy-btn">copy</button>
+          </div>
+          <pre><code class="language-haskell">module Hello
+
+greet(name Str) = printfn "Hello, %s!" name
+Hello = greet "ll-lang"</code></pre>
+        </div>
+      </div>
+
+      <!-- ADTs and pattern matching -->
+      <div>
+        <h3 style="color:var(--text-primary);margin-bottom:.75rem">ADTs and pattern matching</h3>
+        <div class="code-block">
+          <div class="code-block-header">
+            <span class="code-lang">shapes.lll</span>
+            <button class="copy-btn">copy</button>
+          </div>
+          <pre><code class="language-haskell">module Shapes
+
+Shape = Circle Float | Rect Float Float | Empty
+
+area(s Shape) Float =
+  match s with
+  | Circle r -> 3.14159 * r * r
+  | Rect w h -> w * h
+  | Empty    -> 0.0
+
+Shapes =
+  printfn "circle area: %f" (area (Circle 5.0))
+  printfn "rect area:   %f" (area (Rect 3.0 4.0))</code></pre>
+        </div>
+      </div>
+
+      <!-- Tagged types -->
+      <div>
+        <h3 style="color:var(--text-primary);margin-bottom:.75rem">Tagged types (branded strings)</h3>
+        <div class="code-block">
+          <div class="code-block-header">
+            <span class="code-lang">tags.lll</span>
+            <button class="copy-btn">copy</button>
+          </div>
+          <pre><code class="language-haskell">module Tags
+
+tag UserId
+tag Email
+
+-- compiler rejects Str[Email] where Str[UserId] is expected
+getUser(id Str[UserId]) Str = "user:" + id
+sendEmail(to Str[Email]) Str = "sent to " + to
+
+Tags =
+  uid   = "u-42"[UserId]
+  email = "hi@example.com"[Email]
+  printfn "%s" (getUser uid)
+  printfn "%s" (sendEmail email)</code></pre>
+        </div>
+      </div>
+
+      <!-- Traits -->
+      <div>
+        <h3 style="color:var(--text-primary);margin-bottom:.75rem">Traits (ad-hoc polymorphism)</h3>
+        <div class="code-block">
+          <div class="code-block-header">
+            <span class="code-lang">traits.lll</span>
+            <button class="copy-btn">copy</button>
+          </div>
+          <pre><code class="language-haskell">module Traits
+
+trait Show A =
+  show(a A) Str
+
+impl Show Int =
+  show(n Int) Str = intToStr n
+
+impl Show Bool =
+  show(b Bool) Str = if b then "true" else "false"
+
+printVal(x A) [Show A] = printfn "%s" (show x)
+
+Traits =
+  printVal 42
+  printVal true</code></pre>
+        </div>
+      </div>
+
+      <!-- Multi-target build -->
+      <div>
+        <h3 style="color:var(--text-primary);margin-bottom:.75rem">Compile to multiple targets</h3>
+        <div class="code-block">
+          <div class="code-block-header">
+            <span class="code-lang">shell</span>
+            <button class="copy-btn">copy</button>
+          </div>
+          <pre><code class="language-bash"># compile shapes.lll to every stable target
+lllc build --target fs   shapes.lll   # shapes.fs
+lllc build --target ts   shapes.lll   # shapes.ts
+lllc build --target py   shapes.lll   # shapes.py
+lllc build --target java shapes.lll   # Shapes.java
+lllc build --target cs   shapes.lll   # Shapes.cs</code></pre>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</section>
+
+<!-- Footer -->
+<footer>
+  <div class="footer-inner">
+    <span class="footer-logo"><span>//</span>ll-lang</span>
+    <ul class="footer-links">
+      <li><a href="https://github.com/Neftedollar/ll-lang" target="_blank" rel="noopener">GitHub</a></li>
+      <li><a href="docs.html">Docs</a></li>
+      <li><a href="index.html">Home</a></li>
+      <li><a href="https://github.com/Neftedollar/ll-lang/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a></li>
+    </ul>
+    <p class="footer-copy">&copy; 2025 Neftedollar &mdash; ll-lang v1.0.0</p>
+  </div>
+</footer>
+
+<script>hljs.highlightAll();</script>
+<script src="js/main.js"></script>
+</body>
+</html>

--- a/docs-site/robots.txt
+++ b/docs-site/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://neftedollar.github.io/ll-lang/sitemap.xml

--- a/docs-site/sitemap.xml
+++ b/docs-site/sitemap.xml
@@ -10,4 +10,9 @@
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
+  <url>
+    <loc>https://neftedollar.github.io/ll-lang/playground.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
 </urlset>

--- a/docs-site/sitemap.xml
+++ b/docs-site/sitemap.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://neftedollar.github.io/ll-lang/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://neftedollar.github.io/ll-lang/docs.html</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary

- Adds `docs-site/` with `index.html`, `docs.html`, `css/style.css`, `js/main.js`
- Landing page (`index.html`) includes: hero with terminal mockup, stats bar, 3 feature cards with code comparison, 4-step quickstart, MCP integration section, targets grid, community links
- Docs hub (`docs.html`) includes: sidebar navigation + card grid linking to all docs in the repo (language spec, stdlib reference, error codes, grammar EBNF, LLM best practices, MCP, CLI, and more)
- GitHub Actions workflow (`.github/workflows/pages.yml`) deploys `docs-site/` to GitHub Pages on push to `main` (path-filtered to `docs-site/**`)
- Dark-mode design with JetBrains Mono font, highlight.js syntax highlighting, mobile-responsive nav

## Test plan

- [ ] `index.html` renders correctly in browser (open locally)
- [ ] `docs.html` sidebar links resolve on GitHub
- [ ] GitHub Actions `pages.yml` workflow triggers on push to main with `docs-site/` changes
- [ ] Code blocks have syntax highlighting
- [ ] Mobile nav hamburger works on small screens
- [ ] Enable GitHub Pages in repo Settings → Pages → Source: GitHub Actions