### PR TITLE
Start #175: self-default cutover plan + launcher rollout routing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,17 @@ jobs:
       - name: Self-host CLI E2E
         run: ./tools/check-selfhost-e2e.sh
         working-directory: .
+      - name: Self-routing Smoke (safe preset)
+        run: |
+          tmp_dir="$(mktemp -d)"
+          cat > "$tmp_dir/Smoke.lll" <<'SRC'
+          module Smoke
+
+          main() = printfn "smoke"
+          SRC
+          LLLC_BOOTSTRAP_SELF_PRESET=safe ./tools/lllc-bootstrap.sh check "$tmp_dir/Smoke.lll" | rg '"ok":true'
+          LLLC_BOOTSTRAP_SELF_PRESET=safe ./tools/lllc-bootstrap.sh compile "$tmp_dir/Smoke.lll" | rg 'module Smoke'
+        working-directory: .
       - name: LLVM Smoke Chain
         run: ./tools/check-llvm-smoke.sh
         working-directory: .

--- a/NEXT_STEPS
+++ b/NEXT_STEPS
@@ -18,9 +18,11 @@
 - [x] Remove stale references to deleted `src/LLLangTool/Mcp.fs`.
 
 ## Self-hosting path (toward full LLL toolchain)
-- [ ] Define canonical plan to switch default compile/check/run path from stage0 F# to self-hosted pipeline.
+- [x] Define canonical plan to switch default compile/check/run path from stage0 F# to self-hosted pipeline.
+  - [x] Added cutover doc: `docs/compiler-dev/23-selfhost-default-cutover-plan.md` (issue #175).
 - [ ] Add parity gate: same diagnostics and output between stage0 and self-hosted for corpus.
-- [ ] Introduce rollout flag strategy (safe cutover, fallback only for blockers).
+- [x] Introduce rollout flag strategy (safe cutover, fallback only for blockers).
+  - [x] Added launcher routing flags in `tools/lllc-bootstrap.sh` + CI safe preset smoke (issue #175).
 
 ## FFI and MCP roadmap coupling
 - [ ] Finish FFI evolution in `.lll`-owned flow (no new feature logic in F#).

--- a/README.md
+++ b/README.md
@@ -100,6 +100,22 @@ Strict no-fallback launcher:
 `tools/lllc-bootstrap.sh` always executes the pinned bootstrap binary and does
 not fall back to stage0 / `dotnet run` bridge paths.
 
+Self-host routing rollout controls:
+
+```bash
+# default: no routing changes
+LLLC_BOOTSTRAP_SELF_PRESET=off
+
+# route compile/check through self-hosted command path
+LLLC_BOOTSTRAP_SELF_PRESET=safe
+
+# route compile/check/run through self-hosted command path (canary)
+LLLC_BOOTSTRAP_SELF_PRESET=all
+
+# explicit override list
+LLLC_BOOTSTRAP_SELF_COMMANDS=compile,check
+```
+
 ### Run your first program
 
 ```bash

--- a/docs/compiler-dev/23-selfhost-default-cutover-plan.md
+++ b/docs/compiler-dev/23-selfhost-default-cutover-plan.md
@@ -1,0 +1,53 @@
+# Self-Hosted Default Cutover Plan
+
+This document defines the rollout path for making self-hosted `lllcself` the canonical command path for default `lllc` developer workflows.
+
+## Scope
+
+- Commands in scope: `compile`, `check`, `run`.
+- Launcher in scope: `tools/lllc-bootstrap.sh`.
+- Out of scope: backend semantic parity implementation details (tracked separately).
+
+## Why
+
+Today, users can run self-hosted behavior via `lllc self ...`, but default commands still depend on bootstrap binary routing. We need a deterministic, reversible path to make self-hosted behavior the default without breaking teams mid-migration.
+
+## Rollout Controls
+
+`tools/lllc-bootstrap.sh` supports controlled routing through environment variables:
+
+- `LLLC_BOOTSTRAP_SELF_PRESET=off|safe|all`
+- `LLLC_BOOTSTRAP_SELF_COMMANDS=compile,check,run` (explicit override)
+- `LLLC_BOOTSTRAP_SELF_VERBOSE=1` (debug routing decisions)
+
+Preset behavior:
+
+- `off` (default): no routing changes.
+- `safe`: route `compile` + `check` through `self`.
+- `all`: route `compile` + `check` + `run` through `self`.
+
+Rollback is immediate by setting:
+
+```bash
+LLLC_BOOTSTRAP_SELF_PRESET=off
+```
+
+## Phases
+
+1. Phase A (`safe` opt-in):
+- Enable in CI smoke lane.
+- Verify command-shape and diagnostics stability for `compile/check`.
+
+2. Phase B (`all` opt-in in canary lanes):
+- Validate `run` UX/output parity expectations and migration impact.
+
+3. Phase C (default flip):
+- Change default preset from `off` to target preset once parity gate is green.
+- Keep rollback flag documented and tested.
+
+## Exit Criteria for Default Flip
+
+- Parity gate reports no critical divergence for selected corpus.
+- CI includes self-default command routing checks.
+- User docs describe default behavior and rollback procedure.
+- Release notes include cutover status and known deltas.

--- a/tools/lllc-bootstrap.sh
+++ b/tools/lllc-bootstrap.sh
@@ -22,6 +22,13 @@ Behavior:
 Environment:
   LLLC_BOOTSTRAP_AUTO_INSTALL=0   disable auto-install (default: 1)
   LLLC_BOOTSTRAP_REINSTALL=1      force reinstall before run
+  LLLC_BOOTSTRAP_SELF_PRESET=off|safe|all
+                                  command routing preset (default: off)
+                                  safe => compile/check route to `self`
+                                  all  => compile/check/run route to `self`
+  LLLC_BOOTSTRAP_SELF_COMMANDS=compile,check,run
+                                  explicit command list override
+  LLLC_BOOTSTRAP_SELF_VERBOSE=1   print routing decision to stderr
 EOF
 }
 
@@ -39,6 +46,31 @@ fi
 
 AUTO_INSTALL="${LLLC_BOOTSTRAP_AUTO_INSTALL:-1}"
 REINSTALL="${LLLC_BOOTSTRAP_REINSTALL:-0}"
+SELF_PRESET="${LLLC_BOOTSTRAP_SELF_PRESET:-off}"
+
+case "$SELF_PRESET" in
+  off|"")
+    SELF_COMMANDS_DEFAULT=""
+    ;;
+  safe)
+    SELF_COMMANDS_DEFAULT="compile,check"
+    ;;
+  all)
+    SELF_COMMANDS_DEFAULT="compile,check,run"
+    ;;
+  *)
+    fail "invalid LLLC_BOOTSTRAP_SELF_PRESET='$SELF_PRESET' (expected: off|safe|all)"
+    ;;
+esac
+
+SELF_COMMANDS="${LLLC_BOOTSTRAP_SELF_COMMANDS:-$SELF_COMMANDS_DEFAULT}"
+SELF_VERBOSE="${LLLC_BOOTSTRAP_SELF_VERBOSE:-0}"
+
+should_route_to_self() {
+  local cmd="$1"
+  [[ -n "$SELF_COMMANDS" ]] || return 1
+  [[ ",$SELF_COMMANDS," == *",$cmd,"* ]]
+}
 
 if [[ "$AUTO_INSTALL" == "1" ]]; then
   if [[ "$REINSTALL" == "1" ]]; then
@@ -50,5 +82,12 @@ fi
 
 BOOTSTRAP_BIN="$("$INSTALLER" path)"
 [[ -x "$BOOTSTRAP_BIN" ]] || fail "resolved bootstrap binary is not executable: $BOOTSTRAP_BIN"
+
+if [[ "${1:-}" != "self" ]] && should_route_to_self "${1:-}"; then
+  if [[ "$SELF_VERBOSE" == "1" ]]; then
+    echo "lllc-bootstrap: routing '${1}' to self-hosted path" >&2
+  fi
+  set -- self "$@"
+fi
 
 exec "$BOOTSTRAP_BIN" "$@"


### PR DESCRIPTION
## Summary

This PR starts issue #175 by introducing controlled self-host routing at the launcher level and documenting the default cutover plan.

### What changed

1. `tools/lllc-bootstrap.sh`
- Added rollout env controls:
  - `LLLC_BOOTSTRAP_SELF_PRESET=off|safe|all`
  - `LLLC_BOOTSTRAP_SELF_COMMANDS=...` (explicit command override)
  - `LLLC_BOOTSTRAP_SELF_VERBOSE=1`
- Added routing logic:
  - `safe` => route `compile/check` to `self ...`
  - `all` => route `compile/check/run` to `self ...`
- Keeps rollback simple: `LLLC_BOOTSTRAP_SELF_PRESET=off`.

2. CI smoke (`.github/workflows/build.yml`)
- Added `Self-routing Smoke (safe preset)` step to verify launcher routing in CI.

3. Docs
- Added cutover plan doc: `docs/compiler-dev/23-selfhost-default-cutover-plan.md`.
- Updated `README.md` with rollout env usage and examples.
- Updated `NEXT_STEPS` to mark:
  - canonical plan defined,
  - rollout flag strategy introduced.

## Verification

Executed locally:
- `./tools/lllc-bootstrap.sh --help`
- `./tools/lllc-bootstrap.sh check <tmp-file>`
- `LLLC_BOOTSTRAP_SELF_PRESET=safe ./tools/lllc-bootstrap.sh check <tmp-file>`
- `LLLC_BOOTSTRAP_SELF_PRESET=safe ./tools/lllc-bootstrap.sh compile <tmp-file>`
- `./tools/check-doc-contract.sh`

## Notes

- This PR is a controlled rollout foundation, not the final default flip.
- Parity gate work is tracked in #176.

Refs #175