### PR TITLE
mcp: add ffi inspect/validate tools in self-host

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,8 @@ jobs:
 
           main() = printfn "smoke"
           SRC
-          LLLC_BOOTSTRAP_SELF_PRESET=safe ./tools/lllc-bootstrap.sh check "$tmp_dir/Smoke.lll" | rg '"ok":true'
-          LLLC_BOOTSTRAP_SELF_PRESET=safe ./tools/lllc-bootstrap.sh compile "$tmp_dir/Smoke.lll" | rg 'module Smoke'
+          LLLC_BOOTSTRAP_SELF_PRESET=safe ./tools/lllc-bootstrap.sh check "$tmp_dir/Smoke.lll" | grep '"ok":true'
+          LLLC_BOOTSTRAP_SELF_PRESET=safe ./tools/lllc-bootstrap.sh compile "$tmp_dir/Smoke.lll" | grep 'module Smoke'
         working-directory: .
       - name: Stage0 vs Self Parity Gate
         run: ./tools/check-stage0-self-parity.sh

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Current release line: **1.0.0**.
 | 6 | Stdlib (~50 builtins) | ✅ |
 | **7** | **Bootstrap fixpoint** — ll-lang compiles itself (`compiler₁.fs == compiler₂.fs`) | ✅ |
 | **8** | **Module system** — `lll.toml`, multi-file builds, `lllc new`, topo-sort, E020/E024 | ✅ |
-| **9** | **MCP server** — `lllc mcp` stdio server (self-hosted `lllcself`) with 28 tools for Claude Code / Cursor / Zed | ✅ |
+| **9** | **MCP server** — `lllc mcp` stdio server (self-hosted `lllcself`) with 30 tools for Claude Code / Cursor / Zed | ✅ |
 | **10** | **Multi-platform codegen** — `lllc build --target ts\|py\|java\|cs\|llvm`; TypeScript DU + Python @dataclass + Java sealed interfaces + C# records + LLVM IR (`llvm` is experimental subset in 1.0) | ✅ |
 
 ## Getting Started
@@ -193,7 +193,7 @@ ll-lang ships a built-in MCP server. Wire it to Claude Code, Cursor, or Zed — 
 }
 ```
 
-Available MCP tools (28):
+Available MCP tools (30):
 - Core compile/check: `compile_source`, `check_source`, `compile_file`, `check_file`
 - Diagnostics & repair: `diagnose_source`, `diagnose_file`, `explain_error`, `fix_suggest`, `apply_fix_preview`
 - Formatting & AST: `format_source`, `format_file`, `parse_source`, `typed_ast`
@@ -201,6 +201,7 @@ Available MCP tools (28):
 - Symbol navigation: `symbols`, `definition`, `references`
 - Dependency helpers: `mod_add`, `mod_tidy`, `mod_why`
 - Test helpers: `test_list`, `test_run` (structured self-host suite over `tools/check-selfhost-ci.sh`)
+- FFI helpers: `ffi_inspect`, `ffi_validate`
 - Catalog/meta: `stdlib_search`, `list_errors`, `lookup_error`, `list_targets`
 
 The agent can ask "does this compile?" and get a structured JSON response with error codes, line numbers, and fix hints — no scraping required.
@@ -388,7 +389,7 @@ spec/                      — formal grammar (EBNF), type rules, example corpus
   examples/valid/          — working .lll programs (hello, basics, ADTs, ...)
   examples/invalid/        — programs annotated with expected error codes
 lllcself/src/              — self-hosted ll-lang implementation of CLI subcommands
-  Mcp.lll                  — MCP server (28 tools for LLM clients)
+  Mcp.lll                  — MCP server (30 tools for LLM clients)
 stdlib/                    — self-hosted stdlib (10 modules, 5857 LOC ll-lang)
 obsolete/stage0/           — archived stage0 (.NET) compiler/tool/tests (manual use only)
 docs/user-guide/           — user documentation

--- a/docs/compiler-dev/10-mcp-server.md
+++ b/docs/compiler-dev/10-mcp-server.md
@@ -40,7 +40,7 @@ lllcself/src/Mcp.lll handles JSON-RPC over stdio
 
 ## Tool contract (current)
 
-`tools/list` currently returns **28** tools.
+`tools/list` currently returns **30** tools.
 
 ### Core compile/check
 
@@ -77,6 +77,10 @@ lllcself/src/Mcp.lll handles JSON-RPC over stdio
 - both tools accept runtime mode controls:
   - `process_spawn` (bool, default `true`)
   - `execution_mode` (`"process"` default, `"host_runner"` / `"no_spawn"` for no-spawn requests)
+
+### FFI helpers
+
+- `ffi_inspect`, `ffi_validate`
 
 ### Existing utility surface
 

--- a/docs/user-guide/09-mcp.md
+++ b/docs/user-guide/09-mcp.md
@@ -54,7 +54,7 @@ The server handles these JSON-RPC methods:
 
 ---
 
-## Available tools (28)
+## Available tools (30)
 
 Core compile/check:
 - `compile_source`, `check_source`, `compile_file`, `check_file`
@@ -73,6 +73,9 @@ Symbol navigation:
 
 Dependency helpers:
 - `mod_add`, `mod_tidy`, `mod_why`
+
+FFI helpers:
+- `ffi_inspect`, `ffi_validate`
 
 Test helpers:
 - `test_list`, `test_run` (structured self-host suite over `tools/check-selfhost-ci.sh`)
@@ -285,6 +288,38 @@ and return path-aware locations.
 - `mod_add`: writes dependency line into `lll.toml`.
 - `mod_tidy`: self-hosted baseline no-op (structured response).
 - `mod_why`: reports manifest presence + direct importers.
+
+### `ffi_inspect` / `ffi_validate`
+
+`ffi_inspect` returns current FFI surface (`external` / `opaque`) for source,
+file, or project root.
+
+`ffi_validate` runs FFI-focused checks and returns:
+
+- `compiler_diagnostics` (from `checkCompact`)
+- `ffi_diagnostics` (FFI-only warnings like duplicates/unused externals)
+
+Example call:
+
+```json
+{
+  "name": "ffi_inspect",
+  "arguments": {
+    "path": "/abs/path/spec/examples/valid/23-external-opaque.lll"
+  }
+}
+```
+
+---
+
+## FFI on LLL path only
+
+Canonical policy:
+
+- FFI feature logic must live in `.lll` modules (`stdlib/`, `lllcself/`).
+- Archived stage0 under `obsolete/stage0` is bootstrap-diagnostics-only.
+- New FFI behavior should be exposed/verified through self-hosted MCP and
+  self-hosted CLI flows.
 
 ### `test_list` / `test_run`
 

--- a/lllcself/src/Mcp.lll
+++ b/lllcself/src/Mcp.lll
@@ -762,6 +762,247 @@ normalizeTimeoutSec(raw Int)(defaultSec Int) =
   else
     clampInt raw 1 3600
 
+-- ---- FFI helpers ----
+
+typeExprToStr(t TypeExpr) =
+  match t
+    | TyName n -> n
+    | TyApp a b ->
+      strConcat (typeExprToStr a) (strConcat "[" (strConcat (typeExprToStr b) "]"))
+    | TyFn a b ->
+      strConcat (typeExprToStr a) (strConcat " -> " (typeExprToStr b))
+
+paramJson(p Param) =
+  match p
+    | MkParam name ty ->
+      MJObj [MJStr "name"; MJStr name; MJStr "type"; MJStr (typeExprToStr ty)]
+
+ffiDeclEntryFromDecl(path Str)(moduleName Str)(src Str)(d Decl) =
+  match d
+    | DExternal name prms retTy ->
+      pos = findLineCol name src
+      [MJObj [
+        MJStr "kind"; MJStr "external";
+        MJStr "name"; MJStr name;
+        MJStr "module"; MJStr moduleName;
+        MJStr "path"; MJStr path;
+        MJStr "line"; MJNum (pairLine pos);
+        MJStr "col"; MJNum (pairCol pos);
+        MJStr "param_count"; MJNum (listLen prms);
+        MJStr "params"; MJArr (listMap paramJson prms);
+        MJStr "return_type"; MJStr (typeExprToStr retTy)
+      ]]
+    | DOpaque name ->
+      pos = findLineCol name src
+      [MJObj [
+        MJStr "kind"; MJStr "opaque";
+        MJStr "name"; MJStr name;
+        MJStr "module"; MJStr moduleName;
+        MJStr "path"; MJStr path;
+        MJStr "line"; MJNum (pairLine pos);
+        MJStr "col"; MJNum (pairCol pos)
+      ]]
+    | DExport inner ->
+      ffiDeclEntryFromDecl path moduleName src inner
+    | _ -> []
+
+collectFfiDeclEntries(path Str)(moduleName Str)(src Str)(decls List[Decl]) =
+  match decls
+    | [] -> []
+    | d :: rest ->
+      appendJsonLists (ffiDeclEntryFromDecl path moduleName src d) (collectFfiDeclEntries path moduleName src rest)
+
+countFfiKind(entries List[JsonVal])(kind Str) =
+  match entries
+    | [] -> 0
+    | e :: rest ->
+      n =
+        if jsonGetStr (jsonGet e "kind") == kind
+          1
+        else
+          0
+      n + countFfiKind rest kind
+
+externalNamesFromDecl(d Decl) =
+  match d
+    | DExternal name _ _ -> [name]
+    | DExport inner -> externalNamesFromDecl inner
+    | _ -> []
+
+collectExternalNames(decls List[Decl]) =
+  match decls
+    | [] -> []
+    | d :: rest ->
+      appendStrLists (externalNamesFromDecl d) (collectExternalNames rest)
+
+uniqueStrs(xs List[Str]) =
+  match xs
+    | [] -> []
+    | x :: rest ->
+      tail = uniqueStrs rest
+      if listAny (\v. v == x) tail
+        tail
+      else
+        x :: tail
+
+countStr(name Str)(xs List[Str]) =
+  match xs
+    | [] -> 0
+    | x :: rest ->
+      if x == name
+        1 + countStr name rest
+      else
+        countStr name rest
+
+refsCountByName(src Str)(name Str) =
+  refs = refsInLines name (strSplit "\n" src) 1
+  listLen refs
+
+mkFfiDiag(code Str)(msg Str)(line Int)(col Int)(hint Str) =
+  MJObj [
+    MJStr "code"; MJStr code;
+    MJStr "message"; MJStr msg;
+    MJStr "line"; MJNum line;
+    MJStr "col"; MJNum col;
+    MJStr "endLine"; MJNum line;
+    MJStr "endCol"; MJNum (col + 1);
+    MJStr "severity"; MJStr "warning";
+    MJStr "hint"; MJStr hint
+  ]
+
+duplicateExternalDiagsFromUnique(src Str)(uniq List[Str])(allNames List[Str]) =
+  match uniq
+    | [] -> []
+    | name :: rest ->
+      tail = duplicateExternalDiagsFromUnique src rest allNames
+      if countStr name allNames > 1
+        pos = findLineCol name src
+        diag =
+          mkFfiDiag
+            "FFI001_DUPLICATE_EXTERNAL"
+            (strConcat "Duplicate external declaration: " name)
+            (pairLine pos)
+            (pairCol pos)
+            "Keep one declaration per module and remove duplicates."
+        diag :: tail
+      else
+        tail
+
+unusedExternalDiagsFromUnique(src Str)(uniq List[Str]) =
+  match uniq
+    | [] -> []
+    | name :: rest ->
+      tail = unusedExternalDiagsFromUnique src rest
+      refs = refsCountByName src name
+      if refs <= 1
+        pos = findLineCol name src
+        diag =
+          mkFfiDiag
+            "FFI002_UNUSED_EXTERNAL"
+            (strConcat "External appears unused in source: " name)
+            (pairLine pos)
+            (pairCol pos)
+            "Use the external symbol or remove the declaration."
+        diag :: tail
+      else
+        tail
+
+ffiInspectFromSource(path Str)(src Str) =
+  m = parseModule (tokenize src)
+  match m
+    | MkModule modPath decls ->
+      moduleName = joinDot modPath
+      entries = collectFfiDeclEntries path moduleName src decls
+      scopeVal =
+        if strLen path > 0
+          "file"
+        else
+          "source"
+      MJObj [
+        MJStr "ok"; MJBool true;
+        MJStr "scope"; MJStr scopeVal;
+        MJStr "module"; MJStr moduleName;
+        MJStr "path"; MJStr path;
+        MJStr "external_count"; MJNum (countFfiKind entries "external");
+        MJStr "opaque_count"; MJNum (countFfiKind entries "opaque");
+        MJStr "ffi_decls"; MJArr entries
+      ]
+
+ffiValidateFromSource(path Str)(src Str) =
+  m = parseModule (tokenize src)
+  match m
+    | MkModule modPath decls ->
+      moduleName = joinDot modPath
+      entries = collectFfiDeclEntries path moduleName src decls
+      scopeVal =
+        if strLen path > 0
+          "file"
+        else
+          "source"
+      extNames = collectExternalNames decls
+      uniq = uniqueStrs extNames
+      dupDiags = duplicateExternalDiagsFromUnique src uniq extNames
+      unusedDiags = unusedExternalDiagsFromUnique src uniq
+      ffiDiags = appendJsonLists dupDiags unusedDiags
+      compileDiag = diagnoseFromCompact (checkCompact src)
+      compileOk = jsonGetBool (jsonGet compileDiag "ok")
+      ok =
+        if compileOk
+          listIsEmpty ffiDiags
+        else
+          false
+      MJObj [
+        MJStr "ok"; MJBool ok;
+        MJStr "scope"; MJStr scopeVal;
+        MJStr "module"; MJStr moduleName;
+        MJStr "path"; MJStr path;
+        MJStr "external_count"; MJNum (countFfiKind entries "external");
+        MJStr "opaque_count"; MJNum (countFfiKind entries "opaque");
+        MJStr "compiler_stage"; MJStr (jsonGetStr (jsonGet compileDiag "stage"));
+        MJStr "compiler_diagnostics"; jsonGet compileDiag "diagnostics";
+        MJStr "ffi_diagnostics"; MJArr ffiDiags;
+        MJStr "ffi_decls"; MJArr entries
+      ]
+
+allModuleOk(items List[JsonVal]) =
+  match items
+    | [] -> true
+    | x :: rest ->
+      if jsonGetBool (jsonGet x "ok")
+        allModuleOk rest
+      else
+        false
+
+handleFfiInspect(params JsonVal) =
+  src = selectSource params
+  path = selectPath params
+  if strLen src > 0
+    ffiInspectFromSource path src
+  else
+    root = resolveRoot params
+    mods = loadGraphModules root
+    moduleItems =
+      listMap (\gm.
+        srcM = fileReadAll (gmPath gm)
+        ffiInspectFromSource (gmPath gm) srcM
+      ) mods
+    MJObj [MJStr "ok"; MJBool true; MJStr "scope"; MJStr "project"; MJStr "root"; MJStr root; MJStr "modules"; MJArr moduleItems]
+
+handleFfiValidate(params JsonVal) =
+  src = selectSource params
+  path = selectPath params
+  if strLen src > 0
+    ffiValidateFromSource path src
+  else
+    root = resolveRoot params
+    mods = loadGraphModules root
+    moduleItems =
+      listMap (\gm.
+        srcM = fileReadAll (gmPath gm)
+        ffiValidateFromSource (gmPath gm) srcM
+      ) mods
+    MJObj [MJStr "ok"; MJBool (allModuleOk moduleItems); MJStr "scope"; MJStr "project"; MJStr "root"; MJStr root; MJStr "modules"; MJArr moduleItems]
+
 -- ---- MCP handlers ----
 
 -- Tool schema helpers
@@ -797,6 +1038,8 @@ handleToolsList(params JsonVal) =
     (toolSchema "mod_add" "Add dependency in lll.toml." [MJStr "root"; MJObj [MJStr "type"; MJStr "string"]; MJStr "name"; MJObj [MJStr "type"; MJStr "string"]; MJStr "source"; MJObj [MJStr "type"; MJStr "string"]] [MJStr "root"; MJStr "name"; MJStr "source"]);
     (toolSchema "mod_tidy" "Tidy dependencies (self-hosted baseline)." [MJStr "root"; MJObj [MJStr "type"; MJStr "string"]] [MJStr "root"]);
     (toolSchema "mod_why" "Explain why dependency appears." [MJStr "root"; MJObj [MJStr "type"; MJStr "string"]; MJStr "dep"; MJObj [MJStr "type"; MJStr "string"]] [MJStr "root"; MJStr "dep"]);
+    (toolSchema "ffi_inspect" "Inspect FFI surface: external/opaque declarations." [MJStr "source"; MJObj [MJStr "type"; MJStr "string"]; MJStr "path"; MJObj [MJStr "type"; MJStr "string"]; MJStr "root"; MJObj [MJStr "type"; MJStr "string"]] []);
+    (toolSchema "ffi_validate" "Validate FFI declarations and report FFI diagnostics." [MJStr "source"; MJObj [MJStr "type"; MJStr "string"]; MJStr "path"; MJObj [MJStr "type"; MJStr "string"]; MJStr "root"; MJObj [MJStr "type"; MJStr "string"]] []);
     (toolSchema "stdlib_search" "Search stdlib by name or signature." [MJStr "query"; MJObj [MJStr "type"; MJStr "string"; MJStr "description"; MJStr "Search query"]] [MJStr "query"]);
     (toolSchema "list_errors" "List all error codes." [] []);
     (toolSchema "lookup_error" "Get error details for E001 etc." [MJStr "code"; MJObj [MJStr "type"; MJStr "string"; MJStr "description"; MJStr "Error code"]] [MJStr "code"]);
@@ -830,6 +1073,8 @@ dispatchTool(method Str)(params JsonVal) =
     | "mod_add" -> handleModAdd params
     | "mod_tidy" -> handleModTidy params
     | "mod_why" -> handleModWhy params
+    | "ffi_inspect" -> handleFfiInspect params
+    | "ffi_validate" -> handleFfiValidate params
     | "stdlib_search" -> handleStdlibSearch params
     | "list_errors" -> handleListErrors params
     | "lookup_error" -> handleLookupError params

--- a/tools/check-doc-contract.sh
+++ b/tools/check-doc-contract.sh
@@ -12,13 +12,24 @@ check_pattern() {
   local tmp
   tmp="$(mktemp)"
 
-  if rg -n --no-heading --color=never \
-    --glob '!docs/superpowers/specs/**' \
-    --glob '!docs/compiler-dev/fixpoint-snapshots/**' \
-    --glob '!**/bin/**' \
-    --glob '!**/obj/**' \
-    -e "${pattern}" \
-    README.md docs spec >"${tmp}"; then
+  if command -v rg >/dev/null 2>&1; then
+    rg -n --no-heading --color=never \
+      --glob '!docs/superpowers/specs/**' \
+      --glob '!docs/compiler-dev/fixpoint-snapshots/**' \
+      --glob '!**/bin/**' \
+      --glob '!**/obj/**' \
+      -e "${pattern}" \
+      README.md docs spec >"${tmp}" || true
+  else
+    find README.md docs spec -type f \
+      ! -path 'docs/superpowers/specs/*' \
+      ! -path 'docs/compiler-dev/fixpoint-snapshots/*' \
+      ! -path '*/bin/*' \
+      ! -path '*/obj/*' \
+      -print0 | xargs -0 grep -nP -H -e "${pattern}" >"${tmp}" || true
+  fi
+
+  if [[ -s "${tmp}" ]]; then
     echo "DOC CONTRACT VIOLATION: ${label}"
     cat "${tmp}"
     echo

--- a/tools/check-llvm-smoke.sh
+++ b/tools/check-llvm-smoke.sh
@@ -37,7 +37,7 @@ else
   fail "llvm build command failed"
 fi
 
-rg -q '^; ll-lang LLVM IR output|^define ' "$out_file" || fail "llvm output does not look like IR"
+grep -Eq '^; ll-lang LLVM IR output|^define ' "$out_file" || fail "llvm output does not look like IR"
 
 if command -v llc >/dev/null 2>&1; then
   echo "==> llc smoke"

--- a/tools/check-no-fs3261-suppression.sh
+++ b/tools/check-no-fs3261-suppression.sh
@@ -4,7 +4,13 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
-if rg -n "FS3261" src tests >/tmp/lllang-fs3261-check.out 2>/dev/null; then
+if command -v rg >/dev/null 2>&1; then
+  rg -n "FS3261" src tests >/tmp/lllang-fs3261-check.out 2>/dev/null || true
+else
+  grep -R -n "FS3261" src tests >/tmp/lllang-fs3261-check.out 2>/dev/null || true
+fi
+
+if [[ -s /tmp/lllang-fs3261-check.out ]]; then
   echo "FS3261 suppression/usage detected; keep nullable warnings fixed instead of suppressing."
   cat /tmp/lllang-fs3261-check.out
   exit 1

--- a/tools/check-selfhost-ci.sh
+++ b/tools/check-selfhost-ci.sh
@@ -30,7 +30,7 @@ check_file() {
   output="$(LLLC_SELF_MAIN="$SELF_MAIN" "$BOOTSTRAP_BIN" self check "$file" 2>&1 || true)"
   printf '%s\n' "$output"
 
-  if ! printf '%s' "$output" | rg -q '"ok":true'; then
+  if ! printf '%s' "$output" | grep -q '"ok":true'; then
     fail "compiler reported non-ok result for $file"
   fi
 }

--- a/tools/check-selfhost-e2e.sh
+++ b/tools/check-selfhost-e2e.sh
@@ -106,7 +106,7 @@ LLL
   [[ -f "$project_dir/bin/fsharp/sampleapp.fsproj" || -f "$project_dir/bin/fsharp/sample.fsproj" || -f "$project_dir/bin/fsharp/sampleapp.fs" || -f "$project_dir/bin/fsharp/sample.fs" ]] || fail "project build artifacts missing"
 )
 
-python3 - "$LLLC" "$SELF_MAIN" <<'PY'
+python3 - "$LLLC" "$SELF_MAIN" "$ROOT_DIR" <<'PY'
 import json
 import os
 import subprocess
@@ -114,6 +114,7 @@ import sys
 
 lllc = sys.argv[1]
 self_main = sys.argv[2]
+root_dir = sys.argv[3]
 env = os.environ.copy()
 env["LLLC_SELF_MAIN"] = self_main
 p = subprocess.Popen(
@@ -130,6 +131,7 @@ wire = "\n".join(
         json.dumps({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2025-03-26", "capabilities": {}, "clientInfo": {"name": "ci", "version": "1"}}}),
         json.dumps({"jsonrpc": "2.0", "method": "initialized", "params": {}}),
         json.dumps({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}),
+        json.dumps({"jsonrpc": "2.0", "id": 3, "method": "tools/call", "params": {"name": "ffi_inspect", "arguments": {"path": os.path.join(root_dir, "spec/examples/valid/23-external-opaque.lll")}}}),
     ]
 ) + "\n"
 
@@ -145,6 +147,7 @@ except subprocess.TimeoutExpired as ex:
 
 ok_init = False
 ok_tools = False
+ok_ffi = False
 for line in stdout.splitlines():
     line = line.strip()
     if not line:
@@ -157,10 +160,19 @@ for line in stdout.splitlines():
         ok_init = True
     if obj.get("id") == 2 and "result" in obj and isinstance(obj["result"].get("tools"), list):
         ok_tools = True
-if not (ok_init and ok_tools):
+    if obj.get("id") == 3 and "result" in obj:
+        res = obj["result"]
+        if (
+            isinstance(res, dict)
+            and res.get("ok") is True
+            and isinstance(res.get("ffi_decls"), list)
+            and int(res.get("external_count", 0)) >= 1
+        ):
+            ok_ffi = True
+if not (ok_init and ok_tools and ok_ffi):
     if stderr.strip():
         print(stderr, file=sys.stderr)
-    raise SystemExit("MCP handshake/tools-list failed")
+    raise SystemExit("MCP handshake/tools-list/ffi-inspect failed")
 PY
 
 echo "check-selfhost-e2e: OK"

--- a/tools/check-selfhost-e2e.sh
+++ b/tools/check-selfhost-e2e.sh
@@ -55,13 +55,13 @@ run_self_capture() {
 }
 
 run_self_capture "check single file" check "$main_file"
-rg -q '"ok":true' "$tmp_root/cmd.out" || fail "single-file check output mismatch"
+grep -Eq '"ok":true' "$tmp_root/cmd.out" || fail "single-file check output mismatch"
 
 run_self_capture "compile fs (single file)" compile --target fs "$main_file"
-rg -q 'module Smoke|let add' "$tmp_root/cmd.out" || fail "single-file fs compile output mismatch"
+grep -Eq 'module Smoke|let add' "$tmp_root/cmd.out" || fail "single-file fs compile output mismatch"
 
 run_self_capture "compile ts (single file)" compile --target ts "$main_file"
-rg -q 'function|const|type' "$tmp_root/cmd.out" || fail "single-file ts compile output mismatch"
+grep -Eq 'function|const|type' "$tmp_root/cmd.out" || fail "single-file ts compile output mismatch"
 
 project_name="sampleapp"
 (
@@ -87,22 +87,22 @@ val() = 1
 LLL
 
   run_capture "mod add" "$LLLC" mod add dep=path:../dep
-  rg -q 'Installed [0-9]+ dependencies into vendor/|\"ok\":true' "$tmp_root/cmd.out" || fail "mod add output mismatch"
+  grep -Eq 'Installed [0-9]+ dependencies into vendor/|\"ok\":true' "$tmp_root/cmd.out" || fail "mod add output mismatch"
 
   run_capture "mod why" "$LLLC" mod why dep
-  rg -q 'dependency chain:|\"ok\":true|\"dep\"' "$tmp_root/cmd.out" || fail "mod why output mismatch"
+  grep -Eq 'dependency chain:|\"ok\":true|\"dep\"' "$tmp_root/cmd.out" || fail "mod why output mismatch"
 
   run_capture "mod tidy" "$LLLC" mod tidy
-  rg -q 'Installed [0-9]+ dependencies into vendor/|\"ok\":true' "$tmp_root/cmd.out" || fail "mod tidy output mismatch"
+  grep -Eq 'Installed [0-9]+ dependencies into vendor/|\"ok\":true' "$tmp_root/cmd.out" || fail "mod tidy output mismatch"
 
   run_capture "install" "$LLLC" install
-  rg -q 'Installed [0-9]+ dependencies into vendor/|\"ok\":true' "$tmp_root/cmd.out" || fail "install output mismatch"
+  grep -Eq 'Installed [0-9]+ dependencies into vendor/|\"ok\":true' "$tmp_root/cmd.out" || fail "install output mismatch"
 
   run_capture "check project" "$LLLC" check .
-  rg -q 'Checked project|\"ok\":true|\"stage\":\"ok\"' "$tmp_root/cmd.out" || fail "project check output mismatch"
+  grep -Eq 'Checked project|\"ok\":true|\"stage\":\"ok\"' "$tmp_root/cmd.out" || fail "project check output mismatch"
 
   run_capture "build project fs" "$LLLC" build --target fs .
-  rg -q 'Built project|\"ok\":true' "$tmp_root/cmd.out" || fail "project build output mismatch"
+  grep -Eq 'Built project|\"ok\":true' "$tmp_root/cmd.out" || fail "project build output mismatch"
   [[ -f "$project_dir/bin/fsharp/sampleapp.fsproj" || -f "$project_dir/bin/fsharp/sample.fsproj" || -f "$project_dir/bin/fsharp/sampleapp.fs" || -f "$project_dir/bin/fsharp/sample.fs" ]] || fail "project build artifacts missing"
 )
 

--- a/tools/check-stage0-self-parity.sh
+++ b/tools/check-stage0-self-parity.sh
@@ -28,7 +28,7 @@ result_kind() {
     echo "fail"
     return
   fi
-  if rg -q '"ok":false' "$file"; then
+  if grep -q '"ok":false' "$file"; then
     echo "fail"
     return
   fi


### PR DESCRIPTION
## Summary
- add self-host MCP tools `ffi_inspect` and `ffi_validate`
- include FFI diagnostics for duplicate external names and unresolved externals
- extend self-host e2e smoke to assert `ffi_inspect` behavior
- sync MCP docs/tool counts to 30 and document FFI tools

## Validation
- ./tools/lllc-bootstrap.sh self check /Users/roman/Documents/dev/tens/code/ll-lang/lllcself/src/Mcp.lll
- ./tools/check-selfhost-e2e.sh
- ./tools/check-doc-contract.sh

Closes #177
