### PR TITLE
selfhost: default run/compile/check routing and py run path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,8 @@ jobs:
 
           main() = printfn "smoke"
           SRC
-          LLLC_BOOTSTRAP_SELF_PRESET=safe ./tools/lllc-bootstrap.sh check "$tmp_dir/Smoke.lll" | rg '"ok":true'
-          LLLC_BOOTSTRAP_SELF_PRESET=safe ./tools/lllc-bootstrap.sh compile "$tmp_dir/Smoke.lll" | rg 'module Smoke'
+          LLLC_BOOTSTRAP_SELF_PRESET=safe ./tools/lllc-bootstrap.sh check "$tmp_dir/Smoke.lll" | grep '"ok":true'
+          LLLC_BOOTSTRAP_SELF_PRESET=safe ./tools/lllc-bootstrap.sh compile "$tmp_dir/Smoke.lll" | grep 'module Smoke'
         working-directory: .
       - name: Stage0 vs Self Parity Gate
         run: ./tools/check-stage0-self-parity.sh

--- a/README.md
+++ b/README.md
@@ -103,14 +103,14 @@ not fall back to stage0 / `dotnet run` bridge paths.
 Self-host routing rollout controls:
 
 ```bash
-# default: no routing changes
-LLLC_BOOTSTRAP_SELF_PRESET=off
+# default: route compile/check/run through self-hosted command path
+LLLC_BOOTSTRAP_SELF_PRESET=all
 
 # route compile/check through self-hosted command path
 LLLC_BOOTSTRAP_SELF_PRESET=safe
 
-# route compile/check/run through self-hosted command path (canary)
-LLLC_BOOTSTRAP_SELF_PRESET=all
+# disable routing (legacy/stage0 behavior)
+LLLC_BOOTSTRAP_SELF_PRESET=off
 
 # explicit override list
 LLLC_BOOTSTRAP_SELF_COMMANDS=compile,check

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Current release line: **1.0.0**.
 | 6 | Stdlib (~50 builtins) | ✅ |
 | **7** | **Bootstrap fixpoint** — ll-lang compiles itself (`compiler₁.fs == compiler₂.fs`) | ✅ |
 | **8** | **Module system** — `lll.toml`, multi-file builds, `lllc new`, topo-sort, E020/E024 | ✅ |
-| **9** | **MCP server** — `lllc mcp` stdio server (self-hosted `lllcself`) with 28 tools for Claude Code / Cursor / Zed | ✅ |
+| **9** | **MCP server** — `lllc mcp` stdio server (self-hosted `lllcself`) with 30 tools for Claude Code / Cursor / Zed | ✅ |
 | **10** | **Multi-platform codegen** — `lllc build --target ts\|py\|java\|cs\|llvm`; TypeScript DU + Python @dataclass + Java sealed interfaces + C# records + LLVM IR (`llvm` is experimental subset in 1.0) | ✅ |
 
 ## Getting Started
@@ -193,7 +193,7 @@ ll-lang ships a built-in MCP server. Wire it to Claude Code, Cursor, or Zed — 
 }
 ```
 
-Available MCP tools (28):
+Available MCP tools (30):
 - Core compile/check: `compile_source`, `check_source`, `compile_file`, `check_file`
 - Diagnostics & repair: `diagnose_source`, `diagnose_file`, `explain_error`, `fix_suggest`, `apply_fix_preview`
 - Formatting & AST: `format_source`, `format_file`, `parse_source`, `typed_ast`
@@ -201,6 +201,7 @@ Available MCP tools (28):
 - Symbol navigation: `symbols`, `definition`, `references`
 - Dependency helpers: `mod_add`, `mod_tidy`, `mod_why`
 - Test helpers: `test_list`, `test_run` (structured self-host suite over `tools/check-selfhost-ci.sh`)
+- FFI helpers: `ffi_inspect`, `ffi_validate`
 - Catalog/meta: `stdlib_search`, `list_errors`, `lookup_error`, `list_targets`
 
 The agent can ask "does this compile?" and get a structured JSON response with error codes, line numbers, and fix hints — no scraping required.
@@ -388,7 +389,7 @@ spec/                      — formal grammar (EBNF), type rules, example corpus
   examples/valid/          — working .lll programs (hello, basics, ADTs, ...)
   examples/invalid/        — programs annotated with expected error codes
 lllcself/src/              — self-hosted ll-lang implementation of CLI subcommands
-  Mcp.lll                  — MCP server (28 tools for LLM clients)
+  Mcp.lll                  — MCP server (30 tools for LLM clients)
 stdlib/                    — self-hosted stdlib (10 modules, 5857 LOC ll-lang)
 obsolete/stage0/           — archived stage0 (.NET) compiler/tool/tests (manual use only)
 docs/user-guide/           — user documentation

--- a/docs/compiler-dev/10-mcp-server.md
+++ b/docs/compiler-dev/10-mcp-server.md
@@ -40,7 +40,7 @@ lllcself/src/Mcp.lll handles JSON-RPC over stdio
 
 ## Tool contract (current)
 
-`tools/list` currently returns **28** tools.
+`tools/list` currently returns **30** tools.
 
 ### Core compile/check
 
@@ -77,6 +77,10 @@ lllcself/src/Mcp.lll handles JSON-RPC over stdio
 - both tools accept runtime mode controls:
   - `process_spawn` (bool, default `true`)
   - `execution_mode` (`"process"` default, `"host_runner"` / `"no_spawn"` for no-spawn requests)
+
+### FFI helpers
+
+- `ffi_inspect`, `ffi_validate`
 
 ### Existing utility surface
 

--- a/docs/user-guide/08-cli.md
+++ b/docs/user-guide/08-cli.md
@@ -132,11 +132,10 @@ myapp/
 lllc run hello.lll
 ```
 
-1. Same pipeline as `build`.
-2. Materializes a temporary multi-file F# project (`.fs` files + `.fsproj`).
-3. Executes `dotnet run -c Release -v q --project <tmp>.fsproj`.
-4. Propagates the child process exit code.
-5. Deletes the temp directory.
+1. Compiles the source through the self-hosted pipeline.
+2. For `--target py` (default for `run` in self-host path), writes a temporary `.py` file next to the source.
+3. Executes `python3 <temp-file>`.
+4. Prints program stdout.
 
 Your ll-lang `main()` becomes the F# entry point:
 
@@ -150,12 +149,11 @@ lllc run examples/hello.lll
 # Hello, ll-lang!
 ```
 
-For non-F# targets, `lllc run --target <target> file.lll` uses Platform SDK run commands.
-Example TypeScript run path:
+Current self-hosted `run` supports `--target py`:
 
 ```bash
-lllc run --target ts hello.lll
-# internally: npx tsc hello.ts --target es2022 --module esnext && node hello.js
+lllc run hello.lll
+# internally: self compile --target py + python3
 ```
 
 ---
@@ -168,12 +166,10 @@ lllc self compile src/Main.lll
 lllc self symbol src/Main.lll lookupName
 ```
 
-`lllc self` compiles and runs the `lllcself` ll-lang project and delegates subcommands to its CLI (`check`, `compile`, `render`, `tokens`, `next`, `symbol`).
+`lllc self` compiles and runs the `lllcself` ll-lang project and delegates subcommands to its CLI (`check`, `compile`, `run`, `render`, `tokens`, `next`, `symbol`, `mcp`).
 
-In the current `1.x` line, `lllc self` is a bridge into the self-hosted
-compiler/tool layer, not yet the canonical top-level compiler path. The `v2`
-plan is to promote the ll-lang-owned compiler path and demote the stage0 F#
-driver to bootstrap-only support.
+In the current line, `lllc` commands routed via `tools/lllc-bootstrap.sh`
+default to self-host for `compile/check/run`. Stage0 remains bootstrap-only.
 
 ---
 

--- a/docs/user-guide/09-mcp.md
+++ b/docs/user-guide/09-mcp.md
@@ -54,7 +54,7 @@ The server handles these JSON-RPC methods:
 
 ---
 
-## Available tools (28)
+## Available tools (30)
 
 Core compile/check:
 - `compile_source`, `check_source`, `compile_file`, `check_file`
@@ -73,6 +73,9 @@ Symbol navigation:
 
 Dependency helpers:
 - `mod_add`, `mod_tidy`, `mod_why`
+
+FFI helpers:
+- `ffi_inspect`, `ffi_validate`
 
 Test helpers:
 - `test_list`, `test_run` (structured self-host suite over `tools/check-selfhost-ci.sh`)
@@ -285,6 +288,38 @@ and return path-aware locations.
 - `mod_add`: writes dependency line into `lll.toml`.
 - `mod_tidy`: self-hosted baseline no-op (structured response).
 - `mod_why`: reports manifest presence + direct importers.
+
+### `ffi_inspect` / `ffi_validate`
+
+`ffi_inspect` returns current FFI surface (`external` / `opaque`) for source,
+file, or project root.
+
+`ffi_validate` runs FFI-focused checks and returns:
+
+- `compiler_diagnostics` (from `checkCompact`)
+- `ffi_diagnostics` (FFI-only warnings like duplicates/unused externals)
+
+Example call:
+
+```json
+{
+  "name": "ffi_inspect",
+  "arguments": {
+    "path": "/abs/path/spec/examples/valid/23-external-opaque.lll"
+  }
+}
+```
+
+---
+
+## FFI on LLL path only
+
+Canonical policy:
+
+- FFI feature logic must live in `.lll` modules (`stdlib/`, `lllcself/`).
+- Archived stage0 under `obsolete/stage0` is bootstrap-diagnostics-only.
+- New FFI behavior should be exposed/verified through self-hosted MCP and
+  self-hosted CLI flows.
 
 ### `test_list` / `test_run`
 

--- a/lllcself/src/Main.lll
+++ b/lllcself/src/Main.lll
@@ -15,6 +15,7 @@ import Std.CodegenLLVM
 import Lllcself.Mcp
 
 external dirList(path Str) List[Str]
+external processRun(cmd Str)(args List[Str]) Str
 external processRunEx(cmd Str)(args List[Str])(cwd Str)(timeoutSec Int) Str
 
 -- Self-hosted ll-lang CLI.
@@ -460,6 +461,49 @@ runCompile(target Str)(path Str) =
     _ = print (ioError (strConcat "File not found: " path))
     1
 
+runTempPath(path Str)(ext Str) =
+  plen = strLen path
+  if strEndsWith ".lll" path
+    base = strSlice path 0 (plen - 4)
+    strConcat base ext
+  else
+    strConcat path ext
+
+runExecute(target Str)(path Str) =
+  if fileExists path
+    src = readFile path
+    out = compileSourceForTarget target src
+    if strStartsWith "{\"ok\":false" out
+      _ = print out
+      1
+    else
+      t = normalizeTarget target
+      if t == "py"
+        pyPath = runTempPath path ".lllc.run.py"
+        _ = writeFile pyPath out
+        marker = "__LLLC_EXIT__"
+        cmd = "python3 \"$1\" 2>&1; printf \"\\n__LLLC_EXIT__%s\" \"$?\""
+        raw = processRun "sh" ("-lc" :: cmd :: "lllcself-run" :: pyPath :: [])
+        idx = strIndexOf marker raw
+        if idx < 0
+          _ = print raw
+          1
+        else
+          body = strSlice raw 0 idx
+          codeRaw = strSlice raw (idx + strLen marker) (strLen raw - idx - strLen marker)
+          code = strTrim codeRaw
+          _ = print body
+          if code == "0"
+            0
+          else
+            1
+      else
+        _ = print (ioError (strConcat "self run currently supports only --target py (requested: " (strConcat target ")")))
+        1
+  else
+    _ = print (ioError (strConcat "File not found: " path))
+    1
+
 runBuild(target Str)(path Str) =
   if dirExists path
     files = loadProjectFiles path
@@ -612,8 +656,8 @@ runArgs(args List[Str]) =
     | "check" :: path :: [] -> runCheck "fs" path
     | "compile" :: "--target" :: target :: path :: [] -> runCompile target path
     | "compile" :: path :: [] -> runCompile "fs" path
-    | "run" :: "--target" :: target :: path :: [] -> runCompile target path
-    | "run" :: path :: [] -> runCompile "fs" path
+    | "run" :: "--target" :: target :: path :: [] -> runExecute target path
+    | "run" :: path :: [] -> runExecute "py" path
     | "new" :: name :: [] -> runNew name
     | "install" :: [] -> runInstall "."
     | "mod" :: "tidy" :: [] -> runInstall "."

--- a/lllcself/src/Mcp.lll
+++ b/lllcself/src/Mcp.lll
@@ -762,6 +762,247 @@ normalizeTimeoutSec(raw Int)(defaultSec Int) =
   else
     clampInt raw 1 3600
 
+-- ---- FFI helpers ----
+
+typeExprToStr(t TypeExpr) =
+  match t
+    | TyName n -> n
+    | TyApp a b ->
+      strConcat (typeExprToStr a) (strConcat "[" (strConcat (typeExprToStr b) "]"))
+    | TyFn a b ->
+      strConcat (typeExprToStr a) (strConcat " -> " (typeExprToStr b))
+
+paramJson(p Param) =
+  match p
+    | MkParam name ty ->
+      MJObj [MJStr "name"; MJStr name; MJStr "type"; MJStr (typeExprToStr ty)]
+
+ffiDeclEntryFromDecl(path Str)(moduleName Str)(src Str)(d Decl) =
+  match d
+    | DExternal name prms retTy ->
+      pos = findLineCol name src
+      [MJObj [
+        MJStr "kind"; MJStr "external";
+        MJStr "name"; MJStr name;
+        MJStr "module"; MJStr moduleName;
+        MJStr "path"; MJStr path;
+        MJStr "line"; MJNum (pairLine pos);
+        MJStr "col"; MJNum (pairCol pos);
+        MJStr "param_count"; MJNum (listLen prms);
+        MJStr "params"; MJArr (listMap paramJson prms);
+        MJStr "return_type"; MJStr (typeExprToStr retTy)
+      ]]
+    | DOpaque name ->
+      pos = findLineCol name src
+      [MJObj [
+        MJStr "kind"; MJStr "opaque";
+        MJStr "name"; MJStr name;
+        MJStr "module"; MJStr moduleName;
+        MJStr "path"; MJStr path;
+        MJStr "line"; MJNum (pairLine pos);
+        MJStr "col"; MJNum (pairCol pos)
+      ]]
+    | DExport inner ->
+      ffiDeclEntryFromDecl path moduleName src inner
+    | _ -> []
+
+collectFfiDeclEntries(path Str)(moduleName Str)(src Str)(decls List[Decl]) =
+  match decls
+    | [] -> []
+    | d :: rest ->
+      appendJsonLists (ffiDeclEntryFromDecl path moduleName src d) (collectFfiDeclEntries path moduleName src rest)
+
+countFfiKind(entries List[JsonVal])(kind Str) =
+  match entries
+    | [] -> 0
+    | e :: rest ->
+      n =
+        if jsonGetStr (jsonGet e "kind") == kind
+          1
+        else
+          0
+      n + countFfiKind rest kind
+
+externalNamesFromDecl(d Decl) =
+  match d
+    | DExternal name _ _ -> [name]
+    | DExport inner -> externalNamesFromDecl inner
+    | _ -> []
+
+collectExternalNames(decls List[Decl]) =
+  match decls
+    | [] -> []
+    | d :: rest ->
+      appendStrLists (externalNamesFromDecl d) (collectExternalNames rest)
+
+uniqueStrs(xs List[Str]) =
+  match xs
+    | [] -> []
+    | x :: rest ->
+      tail = uniqueStrs rest
+      if listAny (\v. v == x) tail
+        tail
+      else
+        x :: tail
+
+countStr(name Str)(xs List[Str]) =
+  match xs
+    | [] -> 0
+    | x :: rest ->
+      if x == name
+        1 + countStr name rest
+      else
+        countStr name rest
+
+refsCountByName(src Str)(name Str) =
+  refs = refsInLines name (strSplit "\n" src) 1
+  listLen refs
+
+mkFfiDiag(code Str)(msg Str)(line Int)(col Int)(hint Str) =
+  MJObj [
+    MJStr "code"; MJStr code;
+    MJStr "message"; MJStr msg;
+    MJStr "line"; MJNum line;
+    MJStr "col"; MJNum col;
+    MJStr "endLine"; MJNum line;
+    MJStr "endCol"; MJNum (col + 1);
+    MJStr "severity"; MJStr "warning";
+    MJStr "hint"; MJStr hint
+  ]
+
+duplicateExternalDiagsFromUnique(src Str)(uniq List[Str])(allNames List[Str]) =
+  match uniq
+    | [] -> []
+    | name :: rest ->
+      tail = duplicateExternalDiagsFromUnique src rest allNames
+      if countStr name allNames > 1
+        pos = findLineCol name src
+        diag =
+          mkFfiDiag
+            "FFI001_DUPLICATE_EXTERNAL"
+            (strConcat "Duplicate external declaration: " name)
+            (pairLine pos)
+            (pairCol pos)
+            "Keep one declaration per module and remove duplicates."
+        diag :: tail
+      else
+        tail
+
+unusedExternalDiagsFromUnique(src Str)(uniq List[Str]) =
+  match uniq
+    | [] -> []
+    | name :: rest ->
+      tail = unusedExternalDiagsFromUnique src rest
+      refs = refsCountByName src name
+      if refs <= 1
+        pos = findLineCol name src
+        diag =
+          mkFfiDiag
+            "FFI002_UNUSED_EXTERNAL"
+            (strConcat "External appears unused in source: " name)
+            (pairLine pos)
+            (pairCol pos)
+            "Use the external symbol or remove the declaration."
+        diag :: tail
+      else
+        tail
+
+ffiInspectFromSource(path Str)(src Str) =
+  m = parseModule (tokenize src)
+  match m
+    | MkModule modPath decls ->
+      moduleName = joinDot modPath
+      entries = collectFfiDeclEntries path moduleName src decls
+      scopeVal =
+        if strLen path > 0
+          "file"
+        else
+          "source"
+      MJObj [
+        MJStr "ok"; MJBool true;
+        MJStr "scope"; MJStr scopeVal;
+        MJStr "module"; MJStr moduleName;
+        MJStr "path"; MJStr path;
+        MJStr "external_count"; MJNum (countFfiKind entries "external");
+        MJStr "opaque_count"; MJNum (countFfiKind entries "opaque");
+        MJStr "ffi_decls"; MJArr entries
+      ]
+
+ffiValidateFromSource(path Str)(src Str) =
+  m = parseModule (tokenize src)
+  match m
+    | MkModule modPath decls ->
+      moduleName = joinDot modPath
+      entries = collectFfiDeclEntries path moduleName src decls
+      scopeVal =
+        if strLen path > 0
+          "file"
+        else
+          "source"
+      extNames = collectExternalNames decls
+      uniq = uniqueStrs extNames
+      dupDiags = duplicateExternalDiagsFromUnique src uniq extNames
+      unusedDiags = unusedExternalDiagsFromUnique src uniq
+      ffiDiags = appendJsonLists dupDiags unusedDiags
+      compileDiag = diagnoseFromCompact (checkCompact src)
+      compileOk = jsonGetBool (jsonGet compileDiag "ok")
+      ok =
+        if compileOk
+          listIsEmpty ffiDiags
+        else
+          false
+      MJObj [
+        MJStr "ok"; MJBool ok;
+        MJStr "scope"; MJStr scopeVal;
+        MJStr "module"; MJStr moduleName;
+        MJStr "path"; MJStr path;
+        MJStr "external_count"; MJNum (countFfiKind entries "external");
+        MJStr "opaque_count"; MJNum (countFfiKind entries "opaque");
+        MJStr "compiler_stage"; MJStr (jsonGetStr (jsonGet compileDiag "stage"));
+        MJStr "compiler_diagnostics"; jsonGet compileDiag "diagnostics";
+        MJStr "ffi_diagnostics"; MJArr ffiDiags;
+        MJStr "ffi_decls"; MJArr entries
+      ]
+
+allModuleOk(items List[JsonVal]) =
+  match items
+    | [] -> true
+    | x :: rest ->
+      if jsonGetBool (jsonGet x "ok")
+        allModuleOk rest
+      else
+        false
+
+handleFfiInspect(params JsonVal) =
+  src = selectSource params
+  path = selectPath params
+  if strLen src > 0
+    ffiInspectFromSource path src
+  else
+    root = resolveRoot params
+    mods = loadGraphModules root
+    moduleItems =
+      listMap (\gm.
+        srcM = fileReadAll (gmPath gm)
+        ffiInspectFromSource (gmPath gm) srcM
+      ) mods
+    MJObj [MJStr "ok"; MJBool true; MJStr "scope"; MJStr "project"; MJStr "root"; MJStr root; MJStr "modules"; MJArr moduleItems]
+
+handleFfiValidate(params JsonVal) =
+  src = selectSource params
+  path = selectPath params
+  if strLen src > 0
+    ffiValidateFromSource path src
+  else
+    root = resolveRoot params
+    mods = loadGraphModules root
+    moduleItems =
+      listMap (\gm.
+        srcM = fileReadAll (gmPath gm)
+        ffiValidateFromSource (gmPath gm) srcM
+      ) mods
+    MJObj [MJStr "ok"; MJBool (allModuleOk moduleItems); MJStr "scope"; MJStr "project"; MJStr "root"; MJStr root; MJStr "modules"; MJArr moduleItems]
+
 -- ---- MCP handlers ----
 
 -- Tool schema helpers
@@ -797,6 +1038,8 @@ handleToolsList(params JsonVal) =
     (toolSchema "mod_add" "Add dependency in lll.toml." [MJStr "root"; MJObj [MJStr "type"; MJStr "string"]; MJStr "name"; MJObj [MJStr "type"; MJStr "string"]; MJStr "source"; MJObj [MJStr "type"; MJStr "string"]] [MJStr "root"; MJStr "name"; MJStr "source"]);
     (toolSchema "mod_tidy" "Tidy dependencies (self-hosted baseline)." [MJStr "root"; MJObj [MJStr "type"; MJStr "string"]] [MJStr "root"]);
     (toolSchema "mod_why" "Explain why dependency appears." [MJStr "root"; MJObj [MJStr "type"; MJStr "string"]; MJStr "dep"; MJObj [MJStr "type"; MJStr "string"]] [MJStr "root"; MJStr "dep"]);
+    (toolSchema "ffi_inspect" "Inspect FFI surface: external/opaque declarations." [MJStr "source"; MJObj [MJStr "type"; MJStr "string"]; MJStr "path"; MJObj [MJStr "type"; MJStr "string"]; MJStr "root"; MJObj [MJStr "type"; MJStr "string"]] []);
+    (toolSchema "ffi_validate" "Validate FFI declarations and report FFI diagnostics." [MJStr "source"; MJObj [MJStr "type"; MJStr "string"]; MJStr "path"; MJObj [MJStr "type"; MJStr "string"]; MJStr "root"; MJObj [MJStr "type"; MJStr "string"]] []);
     (toolSchema "stdlib_search" "Search stdlib by name or signature." [MJStr "query"; MJObj [MJStr "type"; MJStr "string"; MJStr "description"; MJStr "Search query"]] [MJStr "query"]);
     (toolSchema "list_errors" "List all error codes." [] []);
     (toolSchema "lookup_error" "Get error details for E001 etc." [MJStr "code"; MJObj [MJStr "type"; MJStr "string"; MJStr "description"; MJStr "Error code"]] [MJStr "code"]);
@@ -830,6 +1073,8 @@ dispatchTool(method Str)(params JsonVal) =
     | "mod_add" -> handleModAdd params
     | "mod_tidy" -> handleModTidy params
     | "mod_why" -> handleModWhy params
+    | "ffi_inspect" -> handleFfiInspect params
+    | "ffi_validate" -> handleFfiValidate params
     | "stdlib_search" -> handleStdlibSearch params
     | "list_errors" -> handleListErrors params
     | "lookup_error" -> handleLookupError params

--- a/stdlib/src/CodegenPy.lll
+++ b/stdlib/src/CodegenPy.lll
@@ -80,7 +80,7 @@ emitType(t TypeExpr) =
     | TyName "Bool" -> "bool"
     | TyName "Char" -> "str"
     | TyName "Unit" -> "None"
-    | TyName n -> n
+    | TyName n -> safeIdent n
     | TyApp (TyName "List") a -> strConcat "list[" (strConcat (emitType a) "]")
     | TyApp (TyName "Maybe") a -> strConcat "Optional[" (strConcat (emitType a) "]")
     | TyApp f a -> strConcat (emitType f) (strConcat "[" (strConcat (emitType a) "]"))
@@ -266,7 +266,8 @@ emitCtor(c Constructor) =
   match c
     | MkCon name args ->
       header = "@dataclass"
-      classDef = strConcat (strConcat "class " name) (strConcat ":\n    _tag: str = \"" (strConcat name "\""))
+      safeName = safeIdent name
+      classDef = strConcat (strConcat "class " safeName) (strConcat ":\n    _tag: str = field(init=False, default=\"" (strConcat name "\")"))
       fields = emitCtorField args 0
       if strLen fields == 0
         strConcat header (strConcat "\n" (strConcat classDef "\n    pass"))
@@ -277,8 +278,8 @@ emitCtors(cs List[Constructor]) =
   joinWith "\n\n" (listMap emitCtor cs)
 
 emitUnionAlias(name Str)(cs List[Constructor]) =
-  names = joinWith ", " (listMap (\c. match c | MkCon n _ -> n) cs)
-  strConcat name (strConcat " = Union[" (strConcat names "]"))
+  names = joinWith ", " (listMap (\c. match c | MkCon n _ -> safeIdent n) cs)
+  strConcat (safeIdent name) (strConcat " = Union[" (strConcat names "]"))
 
 emitParamStr(p Param) =
   match p
@@ -306,15 +307,15 @@ emitDecl(d Decl) =
       strConcat "# import " (joinWith "." parts)
     | DExport inner -> emitDecl inner
     | DExternal name _ _ ->
-      strConcat name " = object  # external"
+      strConcat (safeIdent name) " = object  # external"
     | DOpaque name ->
-      strConcat name " = object"
+      strConcat (safeIdent name) " = object"
 
 emitDecls(ds List[Decl]) =
   joinWith "\n\n" (listMap emitDecl ds)
 
 emitPrelude =
-  "# --- ll-lang Python runtime helpers ---\nfrom __future__ import annotations\nfrom dataclasses import dataclass\nfrom typing import Optional, Union, Callable, Any\nimport sys\ndef listLen(xs): return len(xs)\ndef listMap(f): return lambda xs: list(map(f, xs))\ndef listFilter(p): return lambda xs: list(filter(p, xs))\ndef listFold(f): return lambda z: lambda xs: (lambda: (lambda state: [state.__setitem__(0, f(state[0])(x)) for x in xs] or state[0])([z]))()\ndef listReverse(xs): return list(reversed(xs))\ndef listAppend(xs): return lambda ys: xs + ys\ndef listConcat(xss): return [x for xs in xss for x in xs]\ndef listIsEmpty(xs): return len(xs) == 0\ndef listHead(xs): return xs[0] if xs else None\ndef listTail(xs): return xs[1:] if xs else None\ndef strLen(s): return len(s)\ndef strConcat(a): return lambda b: a + b\ndef strChars(s): return list(s)\ndef strFromChars(cs): return ''.join(cs)\ndef strContains(needle): return lambda hay: needle in hay\ndef intToStr(n): return str(n)\ndef charToInt(c): return ord(c)\ndef printfn(s): print(s)\ndef _ll_print(s): sys.stdout.write(s)\n# --- end prelude ---"
+  "# --- ll-lang Python runtime helpers ---\nfrom __future__ import annotations\nfrom dataclasses import dataclass, field\nfrom typing import Optional, Union, Callable, Any\nimport sys\ndef listLen(xs): return len(xs)\ndef listMap(f): return lambda xs: list(map(f, xs))\ndef listFilter(p): return lambda xs: list(filter(p, xs))\ndef listFold(f):\n    return lambda z: (lambda xs: _ll_listFold_impl(f, z, xs))\ndef _ll_listFold_impl(f, z, xs):\n    acc = z\n    for x in xs:\n        acc = f(acc)(x)\n    return acc\ndef listReverse(xs): return list(reversed(xs))\ndef listAppend(xs): return lambda ys: xs + ys\ndef listConcat(xss): return [x for xs in xss for x in xs]\ndef listIsEmpty(xs): return len(xs) == 0\ndef listHead(xs): return xs[0] if xs else None\ndef listTail(xs): return xs[1:] if xs else None\ndef strLen(s): return len(s)\ndef strConcat(a): return lambda b: a + b\ndef strChars(s): return list(s)\ndef strFromChars(cs): return ''.join(cs)\ndef strContains(needle): return lambda hay: needle in hay\ndef intToStr(n): return str(n)\ndef charToInt(c): return ord(c)\ndef charIsDigit(c): return c.isdigit()\ndef charIsAlpha(c): return c.isalpha()\ndef charIsSpace(c): return c.isspace()\ndef printfn(s): print(s)\ndef _ll_print(s): sys.stdout.write(s)\n# --- end prelude ---"
 
 emitModulePath(parts List[Str]) =
   joinWith "." parts

--- a/tools/check-doc-contract.sh
+++ b/tools/check-doc-contract.sh
@@ -12,13 +12,24 @@ check_pattern() {
   local tmp
   tmp="$(mktemp)"
 
-  if rg -n --no-heading --color=never \
-    --glob '!docs/superpowers/specs/**' \
-    --glob '!docs/compiler-dev/fixpoint-snapshots/**' \
-    --glob '!**/bin/**' \
-    --glob '!**/obj/**' \
-    -e "${pattern}" \
-    README.md docs spec >"${tmp}"; then
+  if command -v rg >/dev/null 2>&1; then
+    rg -n --no-heading --color=never \
+      --glob '!docs/superpowers/specs/**' \
+      --glob '!docs/compiler-dev/fixpoint-snapshots/**' \
+      --glob '!**/bin/**' \
+      --glob '!**/obj/**' \
+      -e "${pattern}" \
+      README.md docs spec >"${tmp}" || true
+  else
+    find README.md docs spec -type f \
+      ! -path 'docs/superpowers/specs/*' \
+      ! -path 'docs/compiler-dev/fixpoint-snapshots/*' \
+      ! -path '*/bin/*' \
+      ! -path '*/obj/*' \
+      -print0 | xargs -0 grep -nP -H -e "${pattern}" >"${tmp}" || true
+  fi
+
+  if [[ -s "${tmp}" ]]; then
     echo "DOC CONTRACT VIOLATION: ${label}"
     cat "${tmp}"
     echo

--- a/tools/check-llvm-smoke.sh
+++ b/tools/check-llvm-smoke.sh
@@ -37,7 +37,7 @@ else
   fail "llvm build command failed"
 fi
 
-rg -q '^; ll-lang LLVM IR output|^define ' "$out_file" || fail "llvm output does not look like IR"
+grep -Eq '^; ll-lang LLVM IR output|^define ' "$out_file" || fail "llvm output does not look like IR"
 
 if command -v llc >/dev/null 2>&1; then
   echo "==> llc smoke"

--- a/tools/check-no-fs3261-suppression.sh
+++ b/tools/check-no-fs3261-suppression.sh
@@ -4,7 +4,13 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
-if rg -n "FS3261" src tests >/tmp/lllang-fs3261-check.out 2>/dev/null; then
+if command -v rg >/dev/null 2>&1; then
+  rg -n "FS3261" src tests >/tmp/lllang-fs3261-check.out 2>/dev/null || true
+else
+  grep -R -n "FS3261" src tests >/tmp/lllang-fs3261-check.out 2>/dev/null || true
+fi
+
+if [[ -s /tmp/lllang-fs3261-check.out ]]; then
   echo "FS3261 suppression/usage detected; keep nullable warnings fixed instead of suppressing."
   cat /tmp/lllang-fs3261-check.out
   exit 1

--- a/tools/check-selfhost-ci.sh
+++ b/tools/check-selfhost-ci.sh
@@ -30,7 +30,7 @@ check_file() {
   output="$(LLLC_SELF_MAIN="$SELF_MAIN" "$BOOTSTRAP_BIN" self check "$file" 2>&1 || true)"
   printf '%s\n' "$output"
 
-  if ! printf '%s' "$output" | rg -q '"ok":true'; then
+  if ! printf '%s' "$output" | grep -q '"ok":true'; then
     fail "compiler reported non-ok result for $file"
   fi
 }

--- a/tools/check-selfhost-e2e.sh
+++ b/tools/check-selfhost-e2e.sh
@@ -106,7 +106,7 @@ LLL
   [[ -f "$project_dir/bin/fsharp/sampleapp.fsproj" || -f "$project_dir/bin/fsharp/sample.fsproj" || -f "$project_dir/bin/fsharp/sampleapp.fs" || -f "$project_dir/bin/fsharp/sample.fs" ]] || fail "project build artifacts missing"
 )
 
-python3 - "$LLLC" "$SELF_MAIN" <<'PY'
+python3 - "$LLLC" "$SELF_MAIN" "$ROOT_DIR" <<'PY'
 import json
 import os
 import subprocess
@@ -114,6 +114,7 @@ import sys
 
 lllc = sys.argv[1]
 self_main = sys.argv[2]
+root_dir = sys.argv[3]
 env = os.environ.copy()
 env["LLLC_SELF_MAIN"] = self_main
 p = subprocess.Popen(
@@ -130,6 +131,7 @@ wire = "\n".join(
         json.dumps({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2025-03-26", "capabilities": {}, "clientInfo": {"name": "ci", "version": "1"}}}),
         json.dumps({"jsonrpc": "2.0", "method": "initialized", "params": {}}),
         json.dumps({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}),
+        json.dumps({"jsonrpc": "2.0", "id": 3, "method": "tools/call", "params": {"name": "ffi_inspect", "arguments": {"path": os.path.join(root_dir, "spec/examples/valid/23-external-opaque.lll")}}}),
     ]
 ) + "\n"
 
@@ -145,6 +147,7 @@ except subprocess.TimeoutExpired as ex:
 
 ok_init = False
 ok_tools = False
+ok_ffi = False
 for line in stdout.splitlines():
     line = line.strip()
     if not line:
@@ -157,10 +160,19 @@ for line in stdout.splitlines():
         ok_init = True
     if obj.get("id") == 2 and "result" in obj and isinstance(obj["result"].get("tools"), list):
         ok_tools = True
-if not (ok_init and ok_tools):
+    if obj.get("id") == 3 and "result" in obj:
+        res = obj["result"]
+        if (
+            isinstance(res, dict)
+            and res.get("ok") is True
+            and isinstance(res.get("ffi_decls"), list)
+            and int(res.get("external_count", 0)) >= 1
+        ):
+            ok_ffi = True
+if not (ok_init and ok_tools and ok_ffi):
     if stderr.strip():
         print(stderr, file=sys.stderr)
-    raise SystemExit("MCP handshake/tools-list failed")
+    raise SystemExit("MCP handshake/tools-list/ffi-inspect failed")
 PY
 
 echo "check-selfhost-e2e: OK"

--- a/tools/check-selfhost-e2e.sh
+++ b/tools/check-selfhost-e2e.sh
@@ -55,13 +55,13 @@ run_self_capture() {
 }
 
 run_self_capture "check single file" check "$main_file"
-rg -q '"ok":true' "$tmp_root/cmd.out" || fail "single-file check output mismatch"
+grep -Eq '"ok":true' "$tmp_root/cmd.out" || fail "single-file check output mismatch"
 
 run_self_capture "compile fs (single file)" compile --target fs "$main_file"
-rg -q 'module Smoke|let add' "$tmp_root/cmd.out" || fail "single-file fs compile output mismatch"
+grep -Eq 'module Smoke|let add' "$tmp_root/cmd.out" || fail "single-file fs compile output mismatch"
 
 run_self_capture "compile ts (single file)" compile --target ts "$main_file"
-rg -q 'function|const|type' "$tmp_root/cmd.out" || fail "single-file ts compile output mismatch"
+grep -Eq 'function|const|type' "$tmp_root/cmd.out" || fail "single-file ts compile output mismatch"
 
 project_name="sampleapp"
 (
@@ -87,22 +87,22 @@ val() = 1
 LLL
 
   run_capture "mod add" "$LLLC" mod add dep=path:../dep
-  rg -q 'Installed [0-9]+ dependencies into vendor/|\"ok\":true' "$tmp_root/cmd.out" || fail "mod add output mismatch"
+  grep -Eq 'Installed [0-9]+ dependencies into vendor/|\"ok\":true' "$tmp_root/cmd.out" || fail "mod add output mismatch"
 
   run_capture "mod why" "$LLLC" mod why dep
-  rg -q 'dependency chain:|\"ok\":true|\"dep\"' "$tmp_root/cmd.out" || fail "mod why output mismatch"
+  grep -Eq 'dependency chain:|\"ok\":true|\"dep\"' "$tmp_root/cmd.out" || fail "mod why output mismatch"
 
   run_capture "mod tidy" "$LLLC" mod tidy
-  rg -q 'Installed [0-9]+ dependencies into vendor/|\"ok\":true' "$tmp_root/cmd.out" || fail "mod tidy output mismatch"
+  grep -Eq 'Installed [0-9]+ dependencies into vendor/|\"ok\":true' "$tmp_root/cmd.out" || fail "mod tidy output mismatch"
 
   run_capture "install" "$LLLC" install
-  rg -q 'Installed [0-9]+ dependencies into vendor/|\"ok\":true' "$tmp_root/cmd.out" || fail "install output mismatch"
+  grep -Eq 'Installed [0-9]+ dependencies into vendor/|\"ok\":true' "$tmp_root/cmd.out" || fail "install output mismatch"
 
   run_capture "check project" "$LLLC" check .
-  rg -q 'Checked project|\"ok\":true|\"stage\":\"ok\"' "$tmp_root/cmd.out" || fail "project check output mismatch"
+  grep -Eq 'Checked project|\"ok\":true|\"stage\":\"ok\"' "$tmp_root/cmd.out" || fail "project check output mismatch"
 
   run_capture "build project fs" "$LLLC" build --target fs .
-  rg -q 'Built project|\"ok\":true' "$tmp_root/cmd.out" || fail "project build output mismatch"
+  grep -Eq 'Built project|\"ok\":true' "$tmp_root/cmd.out" || fail "project build output mismatch"
   [[ -f "$project_dir/bin/fsharp/sampleapp.fsproj" || -f "$project_dir/bin/fsharp/sample.fsproj" || -f "$project_dir/bin/fsharp/sampleapp.fs" || -f "$project_dir/bin/fsharp/sample.fs" ]] || fail "project build artifacts missing"
 )
 

--- a/tools/check-stage0-self-parity.sh
+++ b/tools/check-stage0-self-parity.sh
@@ -28,7 +28,7 @@ result_kind() {
     echo "fail"
     return
   fi
-  if rg -q '"ok":false' "$file"; then
+  if grep -q '"ok":false' "$file"; then
     echo "fail"
     return
   fi

--- a/tools/check-stage0-self-parity.sh
+++ b/tools/check-stage0-self-parity.sh
@@ -51,7 +51,7 @@ for rel in "${CORPUS[@]}"; do
   stage0_out="$tmp_root/stage0.$(basename "$rel").out"
   self_out="$tmp_root/self.$(basename "$rel").out"
 
-  if "$LLLC" check "$abs" >"$stage0_out" 2>&1; then
+  if LLLC_BOOTSTRAP_SELF_PRESET=off "$LLLC" check "$abs" >"$stage0_out" 2>&1; then
     stage0_code=0
   else
     stage0_code=$?

--- a/tools/lllc-bootstrap.sh
+++ b/tools/lllc-bootstrap.sh
@@ -23,7 +23,7 @@ Environment:
   LLLC_BOOTSTRAP_AUTO_INSTALL=0   disable auto-install (default: 1)
   LLLC_BOOTSTRAP_REINSTALL=1      force reinstall before run
   LLLC_BOOTSTRAP_SELF_PRESET=off|safe|all
-                                  command routing preset (default: off)
+                                  command routing preset (default: all)
                                   safe => compile/check route to `self`
                                   all  => compile/check/run route to `self`
   LLLC_BOOTSTRAP_SELF_COMMANDS=compile,check,run
@@ -46,7 +46,7 @@ fi
 
 AUTO_INSTALL="${LLLC_BOOTSTRAP_AUTO_INSTALL:-1}"
 REINSTALL="${LLLC_BOOTSTRAP_REINSTALL:-0}"
-SELF_PRESET="${LLLC_BOOTSTRAP_SELF_PRESET:-off}"
+SELF_PRESET="${LLLC_BOOTSTRAP_SELF_PRESET:-all}"
 
 case "$SELF_PRESET" in
   off|"")
@@ -72,6 +72,15 @@ should_route_to_self() {
   [[ ",$SELF_COMMANDS," == *",$cmd,"* ]]
 }
 
+abspath() {
+  local p="$1"
+  if [[ "$p" == /* ]]; then
+    printf '%s\n' "$p"
+  else
+    printf '%s\n' "$(pwd)/$p"
+  fi
+}
+
 if [[ "$AUTO_INSTALL" == "1" ]]; then
   if [[ "$REINSTALL" == "1" ]]; then
     "$INSTALLER" install --reinstall >/dev/null
@@ -84,10 +93,47 @@ BOOTSTRAP_BIN="$("$INSTALLER" path)"
 [[ -x "$BOOTSTRAP_BIN" ]] || fail "resolved bootstrap binary is not executable: $BOOTSTRAP_BIN"
 
 if [[ "${1:-}" != "self" ]] && should_route_to_self "${1:-}"; then
-  if [[ "$SELF_VERBOSE" == "1" ]]; then
-    echo "lllc-bootstrap: routing '${1}' to self-hosted path" >&2
+  route_to_self=1
+  cmd="${1:-}"
+  path_arg=""
+  path_idx=0
+  case "$cmd" in
+    compile|check|run|build)
+      if [[ "${2:-}" == "--target" && -n "${4:-}" ]]; then
+        path_arg="${4:-}"
+        path_idx=4
+      elif [[ -n "${2:-}" ]]; then
+        path_arg="${2:-}"
+        path_idx=2
+      fi
+      ;;
+  esac
+
+  # Keep project-directory check/build on legacy path for now.
+  if [[ "$cmd" == "check" || "$cmd" == "build" ]]; then
+    if [[ -n "$path_arg" && -d "$path_arg" ]]; then
+      route_to_self=0
+    fi
   fi
-  set -- self "$@"
+
+  if [[ "$route_to_self" == "1" ]]; then
+    if [[ "$path_idx" == "4" ]]; then
+      set -- "$1" "$2" "$3" "$(abspath "$path_arg")" "${@:5}"
+    elif [[ "$path_idx" == "2" ]]; then
+      set -- "$1" "$(abspath "$path_arg")" "${@:3}"
+    fi
+    if [[ "$SELF_VERBOSE" == "1" ]]; then
+      echo "lllc-bootstrap: routing '${1}' to self-hosted path" >&2
+    fi
+    set -- self "$@"
+  fi
+fi
+
+if [[ "${1:-}" == "self" && -z "${LLLC_SELF_MAIN:-}" ]]; then
+  DEFAULT_SELF_MAIN="${ROOT_DIR}/lllcself/src/Main.lll"
+  if [[ -f "$DEFAULT_SELF_MAIN" ]]; then
+    export LLLC_SELF_MAIN="$DEFAULT_SELF_MAIN"
+  fi
 fi
 
 exec "$BOOTSTRAP_BIN" "$@"


### PR DESCRIPTION
## Summary
- switch bootstrap default routing to self-host for `compile/check/run` (`LLLC_BOOTSTRAP_SELF_PRESET=all`)
- implement real self-host `run` execution path for `--target py` (non-dotnet)
- fix Python backend generation issues required by self-host runtime execution
- keep stage0 parity check deterministic by forcing legacy routing in stage0 side

## Changes
- `tools/lllc-bootstrap.sh`
  - default preset `off -> all`
  - route only file-level `check/compile/run` via self by default
  - avoid routing project-dir `check/build` yet
  - normalize routed file paths to absolute
  - auto-export `LLLC_SELF_MAIN` when missing
- `lllcself/src/Main.lll`
  - add `processRun` external
  - add `runExecute` for Python target: compile to temp `.py`, execute via shell, propagate output+exit
  - make default `run` target `py`
- `stdlib/src/CodegenPy.lll`
  - safe identifiers for named types/ctors
  - dataclass `_tag` uses `field(init=False, default=...)`
  - prelude fixes (`field` import, helpers: `charIsDigit/Alpha/Space`, robust `listFold`)
- `tools/check-stage0-self-parity.sh`
  - force `LLLC_BOOTSTRAP_SELF_PRESET=off` for stage0 side
- docs
  - `README.md`, `docs/user-guide/08-cli.md` updated for self-default routing and py run behavior

## Validation
- `./tools/lllc-bootstrap.sh self check "$(pwd)/lllcself/src/Main.lll"`
- `./tools/lllc-bootstrap.sh self check "$(pwd)/stdlib/src/CodegenPy.lll"`
- `./tools/check-selfhost-ci.sh`
- `./tools/check-selfhost-e2e.sh`
- `./tools/check-stage0-self-parity.sh`
- `./tools/check-llvm-smoke.sh`
- `./tools/check-doc-contract.sh`
- `./tools/check-no-fs3261-suppression.sh`
- manual smoke: `./tools/lllc-bootstrap.sh run <hello.lll>`

Closes #173
