### PR TITLE
Lock operator precedence baseline and add parser parity fixture

### DIFF
--- a/NEXT_STEPS
+++ b/NEXT_STEPS
@@ -31,13 +31,13 @@
 - [ ] Add docs section: “FFI on LLL path only”.
 
 ## Language ergonomics for compiler-writing
-- [ ] Evaluate built-in operator set (`|>`, `>>=`, `<|>`, `>>`) and lock precedence/associativity.
-- [ ] Add parser parity tests for new surface syntax.
-- [ ] Add TODO markers with fixed categories where blocked:
-  - [ ] `TODO(selfhost:operators)`
-  - [ ] `TODO(selfhost:typing)`
-  - [ ] `TODO(selfhost:resolver)`
-  - [ ] `TODO(selfhost:backend)`
+- [x] Evaluate built-in operator set (`|>`, `>>=`, `<|>`, `>>`) and lock precedence/associativity. (#178)
+- [x] Add parser parity tests for new surface syntax. (#178)
+- [x] Add TODO markers with fixed categories where blocked:
+  - [x] `TODO(selfhost:operators)`
+  - [x] `TODO(selfhost:typing)`
+  - [x] `TODO(selfhost:resolver)`
+  - [x] `TODO(selfhost:backend)`
 
 ## Release readiness checkpoints
 - [ ] Full test suite green (no ignored critical paths except explicitly documented reverse tests).

--- a/docs/compiler-dev/19-v2-syntax-ergonomics-execution.md
+++ b/docs/compiler-dev/19-v2-syntax-ergonomics-execution.md
@@ -57,15 +57,16 @@ starts.
 
 | Operator | ASCII spelling | Role | Associativity | Precedence level |
 |----------|---------------|------|---------------|-----------------|
-| pipe     | `->`          | left-to-right function application | left  | 1 (lowest) |
+| choice   | `<\|>`        | applicative/parser choice           | left  | 1 (lowest) |
 | bind     | `>>=`         | monadic sequencing                  | left  | 2 |
 | sequence | `>>`          | discard-result sequencing           | left  | 2 |
-| choice   | `<\|>`        | applicative/parser choice           | left  | 3 |
+| pipe     | `|>` / `->`   | left-to-right function application  | left  | 3 |
+| compare  | `<` `>` `<=` `>=` `==` `!=` | ordered/equality comparison | left | 4 |
+| cons     | `::`          | list cons                            | right | 5 |
 | add      | `+`           | integer/float addition              | left  | 6 |
 | subtract | `-`           | integer/float subtraction           | left  | 6 |
 | multiply | `*`           | integer/float multiplication        | left  | 7 |
 | divide   | `/`           | integer/float division              | left  | 7 |
-| compare  | `<` `>` `<=` `>=` `==` `!=` | ordered/equality comparison | none | 4 |
 
 **User-defined operator frameworks are out of scope for `v2`.** No new symbolic
 operators may be added without a spec change targeting a later milestone.
@@ -97,11 +98,11 @@ Higher number = tighter binding.
 
 | Level | Operators | Notes |
 |-------|-----------|-------|
-| 1     | `->` (pipe) | loosest; entire pipeline chains at this level |
+| 1     | `<\|>` | loosest; choice chains at the top level |
 | 2     | `>>=` `>>` | monadic/sequencing forms |
-| 3     | `<\|>` | choice; above sequencing, below arithmetic |
-| 4     | `<` `>` `<=` `>=` `==` `!=` | non-associative comparisons |
-| 5     | (reserved) | |
+| 3     | `|>` `->` | pipeline forms (`->` retained as alias in expr context) |
+| 4     | `<` `>` `<=` `>=` `==` `!=` | comparisons |
+| 5     | `::` | right-associative list cons |
 | 6     | `+` `-` | additive arithmetic |
 | 7     | `*` `/` | multiplicative arithmetic |
 | 8     | juxtaposition | function application (tightest) |

--- a/docs/language-spec.md
+++ b/docs/language-spec.md
@@ -234,14 +234,26 @@ main() =
   0
 ```
 
-Current fixed-operator semantics:
+Operator contract (versioned):
 
-- `x |> f` pipes `x` into `f`
-- `m >>= f` lowers as built-in bind-style chaining
-- `a >> b` sequences and returns `b`
-- `a <|> b` is built-in choice syntax
+- **Operator Contract Version:** `1.0.0`
+- **Status:** stable for `1.x` self-host parser surface
+- **Change policy:** any new symbolic operator or precedence change requires a
+  spec version bump.
 
-These operators are fixed language forms, not user-defined operator declarations.
+| Operator | Role | Associativity | Precedence (low -> high) |
+|---|---|---|---|
+| `<|>` | choice | left | 1 |
+| `>>=` | bind | left | 2 |
+| `>>` | sequence (discard left) | left | 2 |
+| `|>` / `->` | pipe (`->` is legacy alias in expression context) | left | 3 |
+| `==` `!=` `<` `>` `<=` `>=` | comparisons | left | 4 |
+| `::` | list cons | right | 5 |
+| `+` `-` | additive arithmetic | left | 6 |
+| `*` `/` | multiplicative arithmetic | left | 7 |
+| application by juxtaposition | function application | left | 8 |
+
+These operators are fixed language forms, not a user-defined operator framework.
 
 ### 2.7 Patterns
 

--- a/docs/user-guide/02-syntax.md
+++ b/docs/user-guide/02-syntax.md
@@ -102,6 +102,22 @@ parameters:
 add = \a b. a + b
 ```
 
+## Fixed operators
+
+ll-lang uses a fixed symbolic operator set (no user-defined operators).
+
+| Operator | Meaning | Associativity | Precedence (low -> high) |
+|---|---|---|---|
+| `<|>` | choice | left | 1 |
+| `>>=` | bind | left | 2 |
+| `>>` | sequence | left | 2 |
+| `|>` / `->` | pipe (`->` kept as expression-level compatibility alias) | left | 3 |
+| `== != < > <= >=` | comparisons | left | 4 |
+| `::` | list cons | right | 5 |
+| `+ -` | arithmetic add/sub | left | 6 |
+| `* /` | arithmetic mul/div | left | 7 |
+| application (`f x`) | function application | left | 8 |
+
 ## `if` / `else`
 
 `if` is an expression — both arms must have the same type. Body is indented

--- a/spec/examples/valid/26-operators-precedence.lll
+++ b/spec/examples/valid/26-operators-precedence.lll
@@ -1,0 +1,27 @@
+module Example.OperatorsPrecedence
+
+Maybe A = Some A | None
+
+inc(x Int) = x + 1
+dbl(x Int) = x * 2
+toSome(x Int) = Some x
+
+pipeChain(x Int) =
+  x |> inc |> dbl
+
+legacyPipeAlias(x Int) =
+  x -> inc -> dbl
+
+bindChain(m Maybe[Int]) =
+  m >>= toSome >>= toSome
+
+seqChain(a Maybe[Int])(b Maybe[Int])(c Maybe[Int]) =
+  a >> b >> c
+
+choiceChain(a Maybe[Int])(b Maybe[Int])(c Maybe[Int]) =
+  a <|> b <|> c
+
+mixed(x Int)(alt Maybe[Int]) =
+  x |> toSome >>= toSome <|> alt
+
+sample = mixed 1 None

--- a/spec/grammar.ebnf
+++ b/spec/grammar.ebnf
@@ -74,7 +74,7 @@ OP_UNDERSCORE  ::= "_"
    Level 1 (loosest): <|>   — parser choice / applicative alternative
    Level 2:           >>= >> — monadic bind, sequence
    Level 3:           -> |>  — left-to-right pipe (both spellings are equivalent)
-   Level 4:           < > <= >= == !=  — comparisons (non-associative)
+   Level 4:           < > <= >= == !=  — comparisons (left-associative)
    Level 5:           ::   — list cons (right-associative)
    Level 6:           + -  — additive arithmetic
    Level 7:           * /  — multiplicative arithmetic
@@ -100,8 +100,8 @@ bind-expr   ::= pipe-expr ((OP_BIND | OP_SEQ) pipe-expr)*
 (* Level 3: pipe — left-associative; both "->" and "|>" are accepted *)
 pipe-expr   ::= cmp-expr ((OP_PIPE | OP_PIPE_FWD) cmp-expr)*
 
-(* Level 4: comparison — non-associative *)
-cmp-expr    ::= cons-expr ((OP_LT | OP_GT | OP_LE | OP_GE | OP_EQ2 | OP_NEQ) cons-expr)?
+(* Level 4: comparison — left-associative *)
+cmp-expr    ::= cons-expr ((OP_LT | OP_GT | OP_LE | OP_GE | OP_EQ2 | OP_NEQ) cons-expr)*
 
 (* Level 5: list cons — right-associative *)
 cons-expr   ::= arith-expr (OP_CONS cons-expr)?
@@ -275,9 +275,8 @@ export-decl  ::= "export" decl
       - type-expr context: type arrow
       - after pattern in match arm: branch arrow
       "|>" is an alias for "->" in expr context only.
-   3. ">>=", ">>", "<|>" are binary operators desugared to curried function application
-      in the AST: `a >>= b` → `EApp(EApp(EVar ">>=", a), b)`.
-      They are NOT special forms — they look up `>>=`, `>>`, `<|>` in scope.
+   3. ">>=", ">>", "<|>", "|>" are parsed as EBinOp forms and lowered later.
+      They are NOT special forms — typing/lowering resolves operator semantics.
       Stdlib modules `Std.State`, `Std.Parsec`, etc. supply the implementations.
    4. "[" disambiguation:
       - tag suffix on a literal: `42[m]` — exactly one IDENT/TYPEID then "]"

--- a/stdlib/src/Codegen.lll
+++ b/stdlib/src/Codegen.lll
@@ -111,6 +111,7 @@ mapOp(op Str) =
     "="
   else if op == "!="
     "<>"
+  -- TODO(selfhost:backend): lower symbolic operators (|>, >>=, >>, <|>) per target semantics.
   else op
 
 -- ---- Type emission ---------------------------------------------------------

--- a/stdlib/src/CompilerInfer.lll
+++ b/stdlib/src/CompilerInfer.lll
@@ -89,6 +89,12 @@ scheme1(v Str)(t TypeExpr) = MkScheme [v] t
 -- Polymorphic scheme with two quantified variables.
 scheme2(v1 Str)(v2 Str)(t TypeExpr) = MkScheme [v1; v2] t
 
+-- TODO(selfhost:typing): evolve these fixed operator schemes into trait-driven dispatch.
+tyPipeOp = TyFn (TyName "a") (TyFn (TyFn (TyName "a") (TyName "b")) (TyName "b"))
+tyBindOp = TyFn (tyMaybe (TyName "a")) (TyFn (TyFn (TyName "a") (tyMaybe (TyName "b"))) (tyMaybe (TyName "b")))
+tyThenThenOp = TyFn (tyMaybe (TyName "a")) (TyFn (tyMaybe (TyName "b")) (tyMaybe (TyName "b")))
+tyChoiceOp = TyFn (tyMaybe (TyName "a")) (TyFn (tyMaybe (TyName "a")) (tyMaybe (TyName "a")))
+
 -- Build the base environment with prelude entries.
 -- Each entry is name -> Scheme.
 baseEnv() =
@@ -156,7 +162,12 @@ baseEnv() =
   e18 = typeEnvInsert "maybeMap" (scheme2 "a" "b" (TyFn (TyFn (TyName "a") (TyName "b")) (TyFn (tyMaybe (TyName "a")) (tyMaybe (TyName "b"))))) e17j
   e18a = typeEnvInsert "maybeBind" (scheme2 "a" "b" (TyFn (tyMaybe (TyName "a")) (TyFn (TyFn (TyName "a") (tyMaybe (TyName "b"))) (tyMaybe (TyName "b"))))) e18
   e18b = typeEnvInsert "maybeWithDefault" (scheme1 "a" (TyFn (TyName "a") (TyFn (tyMaybe (TyName "a")) (TyName "a")))) e18a
-  e18b
+  -- fixed symbolic operators for parser ergonomics
+  e18c = typeEnvInsert "|>" (scheme2 "a" "b" tyPipeOp) e18b
+  e18d = typeEnvInsert ">>=" (scheme2 "a" "b" tyBindOp) e18c
+  e18e = typeEnvInsert ">>" (scheme2 "a" "b" tyThenThenOp) e18d
+  e18f = typeEnvInsert "<|>" (scheme1 "a" tyChoiceOp) e18e
+  e18f
 
 -- ---- Pattern type inference -------------------------------------------
 -- Returns (env_bindings, TypeExpr, errors)
@@ -535,4 +546,3 @@ main =
   _ = inferCheck "12 lambda arith" (runInfer (ELam "n" (EBinOp "+" (EVar "n") (EInt 1)))) "Int -> Int"
 
   printfn "Done"
-

--- a/stdlib/src/Elaborator.lll
+++ b/stdlib/src/Elaborator.lll
@@ -151,6 +151,7 @@ checkExpr(env Env)(e Expr) =
     | EApp f x ->
       listAppend (checkExpr env f) (checkExpr env x)
     | EBinOp _ l r ->
+      -- TODO(selfhost:resolver): resolve and validate symbolic operators against a canonical table.
       listAppend (checkExpr env l) (checkExpr env r)
     | EIf cnd thn els ->
       listAppend (listAppend (checkExpr env cnd) (checkExpr env thn)) (checkExpr env els)

--- a/stdlib/src/Lexer.lll
+++ b/stdlib/src/Lexer.lll
@@ -24,7 +24,7 @@ export Token =
   | IntLit Int | FloatLit Str | StrLit Str | CharLit Char
   -- Operators
   | Arrow | Backslash | Dot | Comma | Colon | ColonColon
-  | Eq | Bar
+  | Eq | Bar | PipeForward | Bind | ThenThen | Choice
   | LBrack | RBrack | LParen | RParen
   | Plus | Minus | Star | Slash | Caret
   | Lt | Gt | Le | Ge | EqEq | Neq
@@ -252,16 +252,36 @@ lexNeq(cs List[Char]) =
     | '=' :: rest -> listAppend [Neq] (lexChars rest)
     | _ -> lexChars cs
 
--- Handle `<` vs `<=`.
-lexLtOrLe(cs List[Char]) =
+-- Handle `<` vs `<=` vs `<|>`.
+lexLtOrLeOrChoice(cs List[Char]) =
   match cs
-    | '=' :: rest -> listAppend [Le] (lexChars rest)
+    | c :: rest ->
+      if c == '='
+        listAppend [Le] (lexChars rest)
+      else if c == '|'
+        match rest
+          | c2 :: rest2 ->
+            if c2 == '>'
+              listAppend [Choice] (lexChars rest2)
+            else listAppend [Lt] (lexChars cs)
+          | _ -> listAppend [Lt] (lexChars cs)
+      else listAppend [Lt] (lexChars cs)
     | _ -> listAppend [Lt] (lexChars cs)
 
--- Handle `>` vs `>=`.
-lexGtOrGe(cs List[Char]) =
+-- Handle `>` vs `>=` vs `>>` vs `>>=`.
+lexGtOrGeOrBind(cs List[Char]) =
   match cs
-    | '=' :: rest -> listAppend [Ge] (lexChars rest)
+    | c :: rest ->
+      if c == '='
+        listAppend [Ge] (lexChars rest)
+      else if c == '>'
+        match rest
+          | c2 :: rest2 ->
+            if c2 == '='
+              listAppend [Bind] (lexChars rest2)
+            else listAppend [ThenThen] (lexChars rest)
+          | _ -> listAppend [ThenThen] (lexChars rest)
+      else listAppend [Gt] (lexChars cs)
     | _ -> listAppend [Gt] (lexChars cs)
 
 -- Handle `-` vs `->` vs `--` (comment).
@@ -290,6 +310,15 @@ lexUnderOrIdent(cs List[Char]) =
       else listAppend [Underscore] (lexChars cs)
     | _ -> listAppend [Underscore] (lexChars cs)
 
+-- Handle `|` vs `|>`.
+lexBarOrPipeForward(cs List[Char]) =
+  match cs
+    | c :: rest ->
+      if c == '>'
+        listAppend [PipeForward] (lexChars rest)
+      else listAppend [Bar] (lexChars cs)
+    | _ -> listAppend [Bar] (lexChars cs)
+
 -- ---- Main lexer loop ---------------------------------------------------
 
 lexChars(cs List[Char]) =
@@ -317,9 +346,9 @@ lexChars(cs List[Char]) =
       else if c == '!'
         lexNeq rest
       else if c == '<'
-        lexLtOrLe rest
+        lexLtOrLeOrChoice rest
       else if c == '>'
-        lexGtOrGe rest
+        lexGtOrGeOrBind rest
       else if c == ':'
         lexColonOrCons rest
       else if c == '('
@@ -331,7 +360,7 @@ lexChars(cs List[Char]) =
       else if c == ']'
         listAppend [RBrack] (lexChars rest)
       else if c == '|'
-        listAppend [Bar] (lexChars rest)
+        lexBarOrPipeForward rest
       else if c == '+'
         listAppend [Plus] (lexChars rest)
       else if c == '*'
@@ -383,6 +412,10 @@ showToken(t Token) =
     | ColonColon -> "ColonColon"
     | Eq       -> "Eq"
     | Bar      -> "Bar"
+    | PipeForward -> "PipeForward"
+    | Bind     -> "Bind"
+    | ThenThen -> "ThenThen"
+    | Choice   -> "Choice"
     | LBrack   -> "LBrack"
     | RBrack   -> "RBrack"
     | LParen   -> "LParen"
@@ -451,8 +484,12 @@ main =
   _ = checkTokens "9 arrow" "->" "Arrow Eof"
   _ = checkTokens "10 backslash" "\\" "Backslash Eof"
   _ = checkTokens "11 pipe" "|" "Bar Eof"
-  _ = checkTokens "12 equals" "=" "Eq Eof"
-  _ = checkTokens "13 let" "let" "KwLet Eof"
-  _ = checkTokens "14 module" "module" "KwModule Eof"
-  _ = checkTokens "15 import" "import" "KwImport Eof"
+  _ = checkTokens "12 pipe-forward" "|>" "PipeForward Eof"
+  _ = checkTokens "13 bind" ">>=" "Bind Eof"
+  _ = checkTokens "14 then-then" ">>" "ThenThen Eof"
+  _ = checkTokens "15 choice" "<|>" "Choice Eof"
+  _ = checkTokens "16 equals" "=" "Eq Eof"
+  _ = checkTokens "17 let" "let" "KwLet Eof"
+  _ = checkTokens "18 module" "module" "KwModule Eof"
+  _ = checkTokens "19 import" "import" "KwImport Eof"
   printfn "Done"

--- a/stdlib/src/Parser.lll
+++ b/stdlib/src/Parser.lll
@@ -250,7 +250,7 @@ parseArmBody(toks List[Token]) =
     | KwIf :: rest -> parseIf rest
     | KwLet :: rest -> parseLetIn rest
     | Ident _ :: Eq :: _ -> parseLetIn toks2
-    | _ -> parseCompare toks2
+    | _ -> parseChoice toks2
 
 skipArrow(toks List[Token]) =
   match toks
@@ -340,7 +340,50 @@ parseExpr(toks List[Token]) =
     | KwLet :: rest -> parseLetIn rest
     | Ident _ :: Eq :: _ -> parseLetIn toks
     | Backslash :: rest -> parseLam rest
-    | _ -> parseCompare toks
+    -- TODO(selfhost:operators): keep this precedence order locked with language-spec.
+    | _ -> parseChoice toks
+
+-- Choice operator `<|>` (loosest): left-associative
+parseChoice(toks List[Token]) =
+  let (e, rest) = parseBind toks
+  parseChoiceTail e rest
+
+parseChoiceTail(lhs Expr)(toks List[Token]) =
+  match toks
+    | Choice :: rest ->
+      let (r, rest2) = parseBind rest
+      parseChoiceTail (EBinOp "<|>" lhs r) rest2
+    | _ -> (lhs, toks)
+
+-- Bind operators `>>=` and `>>`: left-associative
+parseBind(toks List[Token]) =
+  let (e, rest) = parsePipe toks
+  parseBindTail e rest
+
+parseBindTail(lhs Expr)(toks List[Token]) =
+  match toks
+    | Bind :: rest ->
+      let (r, rest2) = parsePipe rest
+      parseBindTail (EBinOp ">>=" lhs r) rest2
+    | ThenThen :: rest ->
+      let (r, rest2) = parsePipe rest
+      parseBindTail (EBinOp ">>" lhs r) rest2
+    | _ -> (lhs, toks)
+
+-- Pipe operators `->` and `|>`: left-associative
+parsePipe(toks List[Token]) =
+  let (e, rest) = parseCompare toks
+  parsePipeTail e rest
+
+parsePipeTail(lhs Expr)(toks List[Token]) =
+  match toks
+    | Arrow :: rest ->
+      let (r, rest2) = parseCompare rest
+      parsePipeTail (EBinOp "|>" lhs r) rest2
+    | PipeForward :: rest ->
+      let (r, rest2) = parseCompare rest
+      parsePipeTail (EBinOp "|>" lhs r) rest2
+    | _ -> (lhs, toks)
 
 -- Comparison operators (==, !=, <, >, <=, >=)
 parseCompare(toks List[Token]) =
@@ -778,6 +821,18 @@ main =
   -- 18. function decl: add(a Int)(b Int) = a + b
   toks18 = Ident "add" :: LParen :: Ident "a" :: TypeId "Int" :: RParen :: LParen :: Ident "b" :: TypeId "Int" :: RParen :: Eq :: Ident "a" :: Plus :: Ident "b" :: Eof :: []
   _ = parserCheckDecl "18 DFn" toks18 "DFn add body=(EBinOp(+ EVar a EVar b))"
+  -- 19. Pipe: 1 |> inc
+  _ = parserCheckExpr "19 pipe forward" (IntLit 1 :: PipeForward :: Ident "inc" :: Eof :: []) "EBinOp(|> EInt 1 EVar inc)"
+  -- 20. Pipe alias: 1 -> inc
+  _ = parserCheckExpr "20 pipe arrow" (IntLit 1 :: Arrow :: Ident "inc" :: Eof :: []) "EBinOp(|> EInt 1 EVar inc)"
+  -- 21. Bind: m >>= f
+  _ = parserCheckExpr "21 bind" (Ident "m" :: Bind :: Ident "f" :: Eof :: []) "EBinOp(>>= EVar m EVar f)"
+  -- 22. Sequence: a >> b
+  _ = parserCheckExpr "22 then then" (Ident "a" :: ThenThen :: Ident "b" :: Eof :: []) "EBinOp(>> EVar a EVar b)"
+  -- 23. Choice: a <|> b
+  _ = parserCheckExpr "23 choice" (Ident "a" :: Choice :: Ident "b" :: Eof :: []) "EBinOp(<|> EVar a EVar b)"
+  -- 24. Mixed precedence: 1 |> inc >>= f <|> alt
+  toks24 = IntLit 1 :: PipeForward :: Ident "inc" :: Bind :: Ident "f" :: Choice :: Ident "alt" :: Eof :: []
+  _ = parserCheckExpr "24 mixed precedence" toks24 "EBinOp(<|> EBinOp(>>= EBinOp(|> EInt 1 EVar inc) EVar f) EVar alt)"
 
   printfn "Done"
-

--- a/tools/check-selfhost-ci.sh
+++ b/tools/check-selfhost-ci.sh
@@ -79,6 +79,7 @@ FILES=(
   "$ROOT_DIR/spec/examples/valid/20z-bootstrap-input-unterminated-char.lll"
   "$ROOT_DIR/spec/examples/valid/21-multi-param-types.lll"
   "$ROOT_DIR/spec/examples/valid/23-external-opaque.lll"
+  "$ROOT_DIR/spec/examples/valid/26-operators-precedence.lll"
   "$ROOT_DIR/spec/examples/valid/30-file-io-external.lll"
   "$ROOT_DIR/spec/examples/valid/hello.lll"
 )

--- a/tools/check-stage0-self-parity.sh
+++ b/tools/check-stage0-self-parity.sh
@@ -17,6 +17,7 @@ CORPUS=(
   "spec/examples/valid/21-multi-param-types.lll"
   "spec/examples/valid/24-pipeline-v2.lll"
   "spec/examples/valid/25-llm-repair-workflow.lll"
+  "spec/examples/valid/26-operators-precedence.lll"
 )
 # Note: 09-lexer-real is currently excluded because self `check` diverges
 # (tracked by parity workstream #176).


### PR DESCRIPTION
## Summary
- lock parser/lexer baseline for `|>`, `>>=`, `>>`, `<|>` with explicit precedence layers (`choice -> bind -> pipe -> compare -> ...`)
- extend self-host infer env with operator schemes for the fixed baseline
- add resolver/backend TODO markers with required categories
- add and wire `spec/examples/valid/26-operators-precedence.lll` into parity/self-host suites
- align docs/spec tables and mark NEXT_STEPS language-ergonomics block as done for #178

Closes #178.

## Validation
- `tools/lllc-bootstrap.sh self check /Users/roman/Documents/dev/tens/code/ll-lang/stdlib/src/Parser.lll`
- `tools/lllc-bootstrap.sh self check /Users/roman/Documents/dev/tens/code/ll-lang/spec/examples/valid/26-operators-precedence.lll`
- `tools/check-stage0-self-parity.sh` (includes new `26-operators-precedence.lll`) -> OK
- `tools/check-doc-contract.sh` -> OK

## Notes
- `tools/check-selfhost-ci.sh` currently fails in this branch at `lllcself/src/Main.lll` with `Unbound variable: dirExists` before reaching corpus checks (pre-existing gate issue outside this change set).